### PR TITLE
Compile problems

### DIFF
--- a/lib/jsonrpc/connectors/httpclient.cpp
+++ b/lib/jsonrpc/connectors/httpclient.cpp
@@ -10,7 +10,7 @@
 #include <curl/curl.h>
 #include <string>
 #include <string.h>
-
+#include <stdlib.h>
 #include <iostream>
 
 using namespace std;


### PR DESCRIPTION
Hi, I tried to compile your library on various Linux distributions but I kept on getting error from g++.
 ‘realloc’ was not declared in this scope
 ‘EXIT_FAILURE’ was not declared in this scope
etc
Including stdlib.h in linb/jsonrpc/connectors/httpclient.cpp seemed to fix this error 
