### PR TITLE
Make support for HTTP protocol non-mandatory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,17 @@ cmake_minimum_required(VERSION 2.6)
 project(libjson-rpc-cpp)
 
 include_directories(lib)
-find_package(CURL REQUIRED)
-include_directories(${CURL_INCLUDE_DIRS})
+set(DEP_LIBS json)
+
+option(USE_HTTP
+       "Support JSON-RPC over HTTP (requires libcurl)" 
+       ON)
+
+if(USE_HTTP)
+  find_package(CURL REQUIRED)
+  include_directories(${CURL_INCLUDE_DIRS})
+  set(DEP_LIBS ${DEP_LIBS} ${CURL_LIBRARIES})
+endif()
 
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out)
@@ -83,13 +92,11 @@ ENABLE_TESTING()
 set(TEST_BINARIES ${CMAKE_BINARY_DIR}/out/test)
 set(CTEST_OUTPUT_ON_FAILURE TRUE)
 
-ADD_TEST(helloworld ${TEST_BINARIES}/helloworld)
-ADD_TEST(remotecounter ${TEST_BINARIES}/remotecounter)
-ADD_TEST(remotecalculator ${TEST_BINARIES}/remotecalculator)
-ADD_TEST(errorhandling ${TEST_BINARIES}/errorhandling)
-ADD_TEST(jsonrpcprotocol ${TEST_BINARIES}/jsonrpcprotocol)
-
-
-
-
+if(USE_HTTP)
+  ADD_TEST(helloworld ${TEST_BINARIES}/helloworld)
+  ADD_TEST(remotecounter ${TEST_BINARIES}/remotecounter)
+  ADD_TEST(remotecalculator ${TEST_BINARIES}/remotecalculator)
+  ADD_TEST(errorhandling ${TEST_BINARIES}/errorhandling)
+  ADD_TEST(jsonrpcprotocol ${TEST_BINARIES}/jsonrpcprotocol)
+endif()
 

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,10 +1,12 @@
 file(COPY res DESTINATION ${CMAKE_BINARY_DIR}/out)
 
-add_executable(jsonrpcserversample simpleserver.cpp)
-target_link_libraries(jsonrpcserversample jsonrpc)
+if(USE_HTTP)
+  add_executable(jsonrpcserversample simpleserver.cpp)
+  target_link_libraries(jsonrpcserversample jsonrpc)
 
-add_executable(jsonrpcclientsample simpleclient.cpp)
-target_link_libraries(jsonrpcclientsample jsonrpc)
+  add_executable(jsonrpcclientsample simpleclient.cpp)
+  target_link_libraries(jsonrpcclientsample jsonrpc)
 
-#add_executable(jsonrpcstubclient simplestubclient.cpp)
-#target_link_libraries(jsonrpcstubclient jsonrpc)
+  #add_executable(jsonrpcstubclient simplestubclient.cpp)
+  #target_link_libraries(jsonrpcstubclient jsonrpc)
+endif()

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,10 @@
 
 add_subdirectory(json)
-add_subdirectory(mongoose)
+
+if(USE_HTTP)
+  add_subdirectory(mongoose)
+  set(DEP_LIBS ${DEP_LIBS} mongoose)
+endif()
+
 add_subdirectory(jsonrpc)
 

--- a/lib/jsonrpc/CMakeLists.txt
+++ b/lib/jsonrpc/CMakeLists.txt
@@ -1,15 +1,21 @@
-file(GLOB_RECURSE jsonrpc_source *.cpp)
+file(GLOB jsonrpc_source *.cpp)
 file(GLOB jsonrpc_header *.h)
-file(GLOB connector_header connectors/*.h)
 
+if(USE_HTTP)
+  file(GLOB http_connector_headers connectors/http*.h)
+  file(GLOB http_connector_sources connectors/http*.cpp)
+  
+  set(jsonrpc_source ${jsonrpc_source} ${http_connector_sources})
+  set(connector_header ${connector_header} ${http_connector_headers})
+endif()
 
 add_library(jsonrpc SHARED ${jsonrpc_source})
 add_library(jsonrpcStatic STATIC ${jsonrpc_source})
 
 set_target_properties(jsonrpcStatic PROPERTIES OUTPUT_NAME jsonrpc)
 
-target_link_libraries(jsonrpc json mongoose ${CURL_LIBRARIES})
-target_link_libraries(jsonrpcStatic json mongoose ${CURL_LIBRARIES})
+target_link_libraries(jsonrpc ${DEP_LIBS})
+target_link_libraries(jsonrpcStatic ${DEP_LIBS})
 
 install(FILES ${jsonrpc_header} DESTINATION include/jsonrpc) 
 install(FILES ${connector_header} DESTINATION include/jsonrpc/connectors) 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,21 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out/test)
 file(COPY procedures.json DESTINATION ${CMAKE_BINARY_DIR}/out/test)
 
-set(COMMON_SOURCES server.cpp)
+if(USE_HTTP)
+  set(COMMON_SOURCES server.cpp)
 
-add_executable(helloworld helloworld.cpp ${COMMON_SOURCES})
-target_link_libraries(helloworld jsonrpc)
+  add_executable(helloworld helloworld.cpp ${COMMON_SOURCES})
+  target_link_libraries(helloworld jsonrpc)
 
-add_executable(remotecounter remotecounter.cpp ${COMMON_SOURCES})
-target_link_libraries(remotecounter jsonrpc)
+  add_executable(remotecounter remotecounter.cpp ${COMMON_SOURCES})
+  target_link_libraries(remotecounter jsonrpc)
 
-add_executable(remotecalculator remotecalculator.cpp ${COMMON_SOURCES})
-target_link_libraries(remotecalculator jsonrpc)
+  add_executable(remotecalculator remotecalculator.cpp ${COMMON_SOURCES})
+  target_link_libraries(remotecalculator jsonrpc)
 
-add_executable(errorhandling errorhandling.cpp ${COMMON_SOURCES})
-target_link_libraries(errorhandling jsonrpc)
+  add_executable(errorhandling errorhandling.cpp ${COMMON_SOURCES})
+  target_link_libraries(errorhandling jsonrpc)
 
-add_executable(jsonrpcprotocol jsonrpcprotocol.cpp ${COMMON_SOURCES})
-target_link_libraries(jsonrpcprotocol jsonrpc)
+  add_executable(jsonrpcprotocol jsonrpcprotocol.cpp ${COMMON_SOURCES})
+  target_link_libraries(jsonrpcprotocol jsonrpc)
+endif()


### PR DESCRIPTION
HTTP protocol support in libjson-rpc-cpp relies on libcurl which
may not be a desirable dependency for some embedded systems. If
another transport for JSON-RPC is used, support for HTTP could be
switched off. This patch makes support for HTTP an option that is
ON by default but could be switched off if not desired.
