### PR TITLE
[+] application may send errors too

### DIFF
--- a/src/jsonrpc/errors.cpp
+++ b/src/jsonrpc/errors.cpp
@@ -8,6 +8,7 @@
  ************************************************************************/
 
 #include "errors.h"
+#include "exception.h"
 
 namespace jsonrpc
 {
@@ -59,17 +60,10 @@ namespace jsonrpc
 
     Json::Value Errors::GetErrorBlock(const Json::Value& request, const int& errorCode)
     {
-        static std::string _emptyString;
-
-        return GetErrorBlock(request, errorCode, _emptyString);
-    }
-
-    Json::Value Errors::GetErrorBlock(const Json::Value& request, const int& errorCode, const std::string& errorMessage)
-    {
         Json::Value error;
         error["jsonrpc"] = "2.0";
         error["error"]["code"] = errorCode;
-        error["error"]["message"] = errorMessage.empty() ? GetErrorMessage(errorCode) : errorMessage;
+        error["error"]["message"] = GetErrorMessage(errorCode);
 
         if(request["id"].isNull())
         {
@@ -79,6 +73,15 @@ namespace jsonrpc
         {
             error["id"] = request["id"].asInt();
         }
+        return error;
+    }
+
+    Json::Value Errors::GetErrorBlock(const Json::Value& request, const JsonRpcException& exc)
+    {
+        Json::Value error = GetErrorBlock(request, exc.GetCode());
+        std::string errorMessage = exc.GetMessage();
+        if ( not errorMessage.empty() )
+            error["error"]["message"] = errorMessage;
         return error;
     }
 

--- a/src/jsonrpc/errors.h
+++ b/src/jsonrpc/errors.h
@@ -17,6 +17,8 @@
 
 namespace jsonrpc
 {   
+    class JsonRpcException;
+
     class Errors
     {
         public:
@@ -29,9 +31,9 @@ namespace jsonrpc
             static Json::Value GetErrorBlock(const Json::Value& request, const int& errorCode);
 
             /**
-             * Same as previous, but with user-supplied message.
+             * Same as previous, but using user-generated exception.
              */
-            static Json::Value GetErrorBlock(const Json::Value& request, const int& errorCode, const std::string& errorMessage);
+            static Json::Value GetErrorBlock(const Json::Value& request, const JsonRpcException& exc);
 
             /**
              * @return error message to corresponding error code.

--- a/src/jsonrpc/rpcprotocolserver.cpp
+++ b/src/jsonrpc/rpcprotocolserver.cpp
@@ -90,7 +90,7 @@ namespace jsonrpc
             }
             catch (const JsonRpcException & exc)
             {
-                response = Errors::GetErrorBlock(req, exc.GetCode(), exc.GetMessage());
+                response = Errors::GetErrorBlock(req, exc);
             }
         }
         else


### PR DESCRIPTION
User-defined server application may send its own errors throwing JsonRpcException. For example, it becomes possible to validate arguments, more complex than just integer or string.
