### PR TITLE
bugfix in HandleBatchRequest()

### DIFF
--- a/src/jsonrpc/rpcprotocolserver.cpp
+++ b/src/jsonrpc/rpcprotocolserver.cpp
@@ -103,7 +103,7 @@ namespace jsonrpc
     {
         for (unsigned int i = 0; i < req.size(); i++)
         {
-            this->HandleSingleRequest(req, response[i]);
+            this->HandleSingleRequest(req[i], response[i]);
         }
     }
 


### PR DESCRIPTION
My RPC server built with libjson-rpc caused a crash when it received a batch request. This patch fixes the issue.
