### PR TITLE
Allow multiple calls to the same method in a batch request.

### DIFF
--- a/src/jsonrpc/rpcprotocolclient.h
+++ b/src/jsonrpc/rpcprotocolclient.h
@@ -17,7 +17,7 @@
 
 namespace jsonrpc {
 
-    typedef std::map<const std::string, const Json::Value> batchProcedureCall_t;
+    typedef std::multimap<const std::string, const Json::Value> batchProcedureCall_t;
 
     /**
      * @brief The RpcProtocolClient class handles the json-rpc 2.0 protocol for the client side.


### PR DESCRIPTION
jsonrpc::batchProcedureCall_t is now a std::multimap. Adding
several calls to the same method works as expected.
