### PR TITLE
Condition HTTP connector compilation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,22 @@
 cmake_minimum_required(VERSION 2.6)
 project(libjson-rpc-cpp)
 
+SET(HTTP_CONNECTOR YES CACHE BOOL "Include HTTP connector inside library")
 
-find_package(CURL REQUIRED)
-include_directories(${CURL_INCLUDE_DIRS})
+if (HTTP_CONNECTOR)
+  find_package(CURL REQUIRED)
+  include_directories(${CURL_INCLUDE_DIRS})
+  ADD_DEFINITIONS(-DHTTP_CONNECTOR)
+endif()
 
-include_directories(${CMAKE_SOURCE_DIR}/src/deps)
 include_directories(${CMAKE_SOURCE_DIR}/src)
 
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out)
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out)
 
-SET(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
-SET(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -Wall")
+# SET(CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS_DEBUG} -Wall")
+# SET(CMAKE_C_FLAGS_DEBUG     "${CMAKE_C_FLAGS_DEBUG} -Wall")
 
 
 SET(MAJOR_VERSION 0)
@@ -32,9 +35,10 @@ install(FILES ${PROJECT_BINARY_DIR}/version.h DESTINATION include/jsonrpc)
 
 
 add_subdirectory(src/jsonrpc)
-add_subdirectory(src/test)
 add_subdirectory(src/stubgenerator)
-add_subdirectory(src/example)
+if (HTTP_CONNECTOR)
+  add_subdirectory(src/example)
+endif()
 
 
 # uninstall target
@@ -98,14 +102,4 @@ ENABLE_TESTING()
 set(TEST_BINARIES ${CMAKE_BINARY_DIR}/out/test)
 set(CTEST_OUTPUT_ON_FAILURE TRUE)
 
-ADD_TEST(helloworld ${TEST_BINARIES}/helloworld)
-ADD_TEST(remotecounter ${TEST_BINARIES}/remotecounter)
-ADD_TEST(remotecalculator ${TEST_BINARIES}/remotecalculator)
-ADD_TEST(errorhandling ${TEST_BINARIES}/errorhandling)
-ADD_TEST(jsonrpcprotocol ${TEST_BINARIES}/jsonrpcprotocol)
-ADD_TEST(specification ${TEST_BINARIES}/specification)
-ADD_TEST(parametervalidation ${TEST_BINARIES}/parametervalidation)
-
-
-
-
+add_subdirectory(src/test)

--- a/build/buildhere.txt
+++ b/build/buildhere.txt
@@ -1,6 +1,0 @@
-Run the following commands:
-
-cmake ..
-make
-sudo make install
-sudo ldconfig

--- a/src/jsonrpc/CMakeLists.txt
+++ b/src/jsonrpc/CMakeLists.txt
@@ -1,22 +1,40 @@
-file(GLOB_RECURSE jsonrpc_source *.c*)
+file(GLOB jsonrpc_source *.cpp json/*.c*)
 file(GLOB jsonrpc_header *.h)
-file(GLOB connector_header connectors/*.h)
+
+set(JSONRPC_DEPENDENCIES)
+
+if(HTTP_CONNECTOR)
+	file(GLOB connector_mongoose_source connectors/mongoose*.c*)
+	file(GLOB connector_mongoose_header connectors/mongoose*.h)
+	file(GLOB connector_http_source connectors/http*.c*)
+	file(GLOB connector_http_header connectors/http*.h)
+	set(JSONRPC_DEPENDENCIES ${JSONRPC_DEPENDENCIES} ${CURL_LIBRARIES} pthread dl)
+endif()
+
 file(GLOB jsoncpp_header json/*.h)
 
-add_library(jsonrpc SHARED ${jsonrpc_source})
-add_library(jsonrpcStatic STATIC ${jsonrpc_source})
+set(connectors_source ${connector_http_source} ${connector_mongoose_source})
+set(connectors_header ${connector_http_source} ${connector_mongoose_source})
+
+
+add_library(jsonrpc SHARED ${jsonrpc_source} ${connectors_source})
+add_library(jsonrpcStatic STATIC ${jsonrpc_source} ${connectors_source})
 
 set_target_properties(jsonrpcStatic PROPERTIES OUTPUT_NAME jsonrpc)
 
 set(VERSION_STRING ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}) 
 set_target_properties(jsonrpc jsonrpcStatic PROPERTIES VERSION "${VERSION_STRING}" SOVERSION "${VERSION_MAJOR}")
 
-target_link_libraries(jsonrpc pthread dl ${CURL_LIBRARIES})
-target_link_libraries(jsonrpcStatic pthread dl ${CURL_LIBRARIES})
+target_link_libraries(jsonrpc ${JSONRPC_DEPENDENCIES})
+target_link_libraries(jsonrpcStatic ${JSONRPC_DEPENDENCIES})
 
-install(FILES ${jsonrpc_header} DESTINATION include/jsonrpc) 
-install(FILES ${connector_header} DESTINATION include/jsonrpc/connectors)
-install(FILES ${jsoncpp_header} DESTINATION include/jsonrpc/json) 
+
+
+install(FILES ${jsonrpc_header} DESTINATION include/jsonrpc)
+install(FILES ${jsoncpp_header} DESTINATION include/jsonrpc/json)
+if(MONGOOSE_CONNECTOR OR HTTP_CONNECTOR)
+	install(FILES ${connectors_header} DESTINATION include/jsonrpc/connectors)
+endif()
 
 install(TARGETS jsonrpc jsonrpcStatic LIBRARY DESTINATION lib
                       ARCHIVE DESTINATION lib

--- a/src/jsonrpc/errors.cpp
+++ b/src/jsonrpc/errors.cpp
@@ -80,7 +80,7 @@ namespace jsonrpc
     {
         Json::Value error = GetErrorBlock(request, exc.GetCode());
         std::string errorMessage = exc.GetMessage();
-        if ( not errorMessage.empty() )
+        if ( ! errorMessage.empty() )
             error["error"]["message"] = errorMessage;
         return error;
     }

--- a/src/jsonrpc/rpc.h
+++ b/src/jsonrpc/rpc.h
@@ -16,8 +16,10 @@
 //For error handling and catching Exceptions.
 #include "exception.h"
 
-#include "connectors/httpserver.h"
-#include "connectors/httpclient.h"
+#ifdef HTTP_CONNECTOR
+  #include "connectors/httpserver.h"
+  #include "connectors/httpclient.h"
+#endif
 
 #include "specificationparser.h"
 #include "specificationwriter.h"

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,24 +1,37 @@
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out/test)
 
-set(COMMON_SOURCES server.cpp)
 
-add_executable(helloworld helloworld.cpp ${COMMON_SOURCES})
-target_link_libraries(helloworld jsonrpc)
+if (HTTP_CONNECTOR)
+	set(COMMON_SOURCES server.cpp)
+	add_executable(helloworld helloworld.cpp ${COMMON_SOURCES})
+	target_link_libraries(helloworld jsonrpc)
 
-add_executable(remotecounter remotecounter.cpp ${COMMON_SOURCES})
-target_link_libraries(remotecounter jsonrpc)
+	add_executable(remotecounter remotecounter.cpp ${COMMON_SOURCES})
+	target_link_libraries(remotecounter jsonrpc)
 
-add_executable(remotecalculator remotecalculator.cpp ${COMMON_SOURCES})
-target_link_libraries(remotecalculator jsonrpc)
+	add_executable(remotecalculator remotecalculator.cpp ${COMMON_SOURCES})
+	target_link_libraries(remotecalculator jsonrpc)
 
-add_executable(errorhandling errorhandling.cpp ${COMMON_SOURCES})
-target_link_libraries(errorhandling jsonrpc)
+	add_executable(errorhandling errorhandling.cpp ${COMMON_SOURCES})
+	target_link_libraries(errorhandling jsonrpc)
 
-add_executable(jsonrpcprotocol jsonrpcprotocol.cpp ${COMMON_SOURCES})
-target_link_libraries(jsonrpcprotocol jsonrpc)
+	add_executable(jsonrpcprotocol jsonrpcprotocol.cpp ${COMMON_SOURCES})
+	target_link_libraries(jsonrpcprotocol jsonrpc)
 
-add_executable(specification specification.cpp ${COMMON_SOURCES})
-target_link_libraries(specification jsonrpc)
+	add_executable(specification specification.cpp ${COMMON_SOURCES})
+	target_link_libraries(specification jsonrpc)
+
+	ADD_TEST(helloworld ${TEST_BINARIES}/helloworld)
+	ADD_TEST(remotecounter ${TEST_BINARIES}/remotecounter)
+	ADD_TEST(remotecalculator ${TEST_BINARIES}/remotecalculator)
+	ADD_TEST(errorhandling ${TEST_BINARIES}/errorhandling)
+	ADD_TEST(jsonrpcprotocol ${TEST_BINARIES}/jsonrpcprotocol)
+	ADD_TEST(specification ${TEST_BINARIES}/specification)
+endif()
+
 
 add_executable(parametervalidation parametervalidation.cpp)
 target_link_libraries(parametervalidation jsonrpc)
+
+
+ADD_TEST(parametervalidation ${TEST_BINARIES}/parametervalidation)


### PR DESCRIPTION
I create a patch to condition HTTPconnector compilation.

In deed HTTP connector (even if it is very usefull) is not always needed. With this patch, compilation of these modules is conditioned via CMake variable (HTTP_CONNECTOR).

Tests/examples depending on HTTP connector are build if and only if the associated connector is activated.
