### PR TITLE
Don't free memory you didn't have allocated yourself.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ using namespace std;
 
 int main()
 {
-    MyStubClient c(new HttpClient("http://localhost:8080"));
+    HttpClient* httpClient = new HttpClient("http://localhost:8080");
+    MyStubClient c(httpClient);
     try
     {
         cout << c.sayHello("Peter Knafl") << endl;
@@ -207,7 +208,8 @@ int main()
     {
         cerr << e.what() << endl;
     }
-	return 0;
+    delete httpClient;
+    return 0;
 }
 ```
 

--- a/src/example/simpleclient.cpp
+++ b/src/example/simpleclient.cpp
@@ -13,7 +13,8 @@ using namespace std;
 
 int main()
 {
-    Client c(new HttpClient("https://localhost:8080"));
+    HttpClient* httpClient = new HttpClient("http://localhost:8080");
+    Client c(httpClient);
 
     Json::Value params;
     params["name"] = "Peter";
@@ -27,5 +28,5 @@ int main()
         cerr << e.what() << endl;
     }
 
-
+    delete httpClient;
 }

--- a/src/example/stubclient.cpp
+++ b/src/example/stubclient.cpp
@@ -17,7 +17,8 @@ using namespace std;
 
 int main()
 {
-    MyStubClient c(new HttpClient("http://localhost:8080"));
+    HttpClient* httpClient = new HttpClient("http://localhost:8080");
+    MyStubClient c(httpClient);
 
     try
     {
@@ -32,6 +33,6 @@ int main()
         cerr << e.what() << endl;
     }
 
-
+    delete httpClient;
 }
 

--- a/src/example/xbmcremote.cpp
+++ b/src/example/xbmcremote.cpp
@@ -85,7 +85,8 @@ int main(int argc, char** argv) {
     {
         cout << "XBMC Remote: a,s,d,w for navigation, enter for select, escape or backspace for back button" << endl;
         try {
-            XbmcRemoteClient stub(new HttpClient(argv[1]));
+            HttpClient* httpClient = new HttpClient(argv[1]);
+            XbmcRemoteClient stub(httpClient);
             int key = 0;
             for (;;) {
 #ifdef __APPLE__
@@ -111,6 +112,7 @@ int main(int argc, char** argv) {
                 }
                 cout << "Pressed: " << key << endl;
             }
+            delete httpClient;
         } catch(jsonrpc::JsonRpcException e) {
             cerr << e.what() << endl;
         }

--- a/src/jsonrpc/client.cpp
+++ b/src/jsonrpc/client.cpp
@@ -19,11 +19,6 @@ namespace jsonrpc
     {
     }
 
-    Client::~Client()
-    {
-        delete this->connector;
-    }
-
     void Client::CallMethod(const std::string &name, const Json::Value &paramter, Json::Value& result) throw(JsonRpcException)
     {
         std::string request, response;

--- a/src/jsonrpc/client.h
+++ b/src/jsonrpc/client.h
@@ -23,7 +23,6 @@ namespace jsonrpc
     {
         public:
             Client(AbstractClientConnector* connector);
-            ~Client();
 
 
             void CallMethod(const std::string &name, const Json::Value &paramter, Json::Value& result) throw (JsonRpcException);

--- a/src/test/errorhandling.cpp
+++ b/src/test/errorhandling.cpp
@@ -16,7 +16,7 @@ using namespace std;
 int main(int argc, char** argv)
 {
     TestServer* server = new TestServer();
-     TestServer* server2 = new TestServer();
+    TestServer* server2 = new TestServer();
 
     //Server Startup and shutdown tests
     if(!server->StartListening())
@@ -56,7 +56,8 @@ int main(int argc, char** argv)
     server->StopListening();
 
     //Client startup and shutdown tests
-    Client* client = new Client(new HttpClient("http://localhost:8080"));
+    HttpClient *httpClient = new HttpClient("http://localhost:8080");
+    Client* client = new Client(httpClient);
 
     int error = 0;
     try
@@ -67,6 +68,9 @@ int main(int argc, char** argv)
     {
         error = e.GetCode();
     }
+
+    delete client;
+    delete httpClient;
 
     if(error != -32003)
     {

--- a/src/test/helloworld.cpp
+++ b/src/test/helloworld.cpp
@@ -22,7 +22,8 @@ int main(int argc, char** argv)
 {
 
     TestServer* server = new TestServer();
-    Client* client = new Client(new HttpClient("http://localhost:8080"));
+    HttpClient *httpClient = new HttpClient("http://localhost:8080");
+    Client* client = new Client(httpClient);
 
     cout << SpecificationWriter::toString(server->GetProtocolHanlder()->GetProcedures()) << endl;
 
@@ -47,6 +48,7 @@ int main(int argc, char** argv)
 
         delete server;
         delete client;
+        delete httpClient;
 
         cout << argv[0] << " passed" << endl;
 
@@ -57,6 +59,7 @@ int main(int argc, char** argv)
         cerr << "Exception occured: " << e.what() << endl;
         delete server;
         delete client;
+        delete httpClient;
         return -999;
     }
 }

--- a/src/test/jsonrpcprotocol.cpp
+++ b/src/test/jsonrpcprotocol.cpp
@@ -39,7 +39,8 @@ int main(int argc, char** argv)
 {
 
     TestServer* server = new TestServer();
-    Client* client = new Client(new HttpClient("http://localhost:8080"));
+    HttpClient *httpClient = new HttpClient("http://localhost:8080");
+    Client* client = new Client(httpClient);
     server->StartListening();
 
     Json::Value v;
@@ -73,6 +74,7 @@ int main(int argc, char** argv)
 
     delete server;
     delete client;
+    delete httpClient;
 
     return 0;
 }

--- a/src/test/remotecalculator.cpp
+++ b/src/test/remotecalculator.cpp
@@ -20,7 +20,8 @@ int main(int argc, char** argv)
 {
 
     TestServer* server = new TestServer();
-    Client* client = new Client(new HttpClient("http://localhost:8080"));
+    HttpClient *httpClient = new HttpClient("http://localhost:8080");
+    Client* client = new Client(httpClient);
 
     try {
         server->StartListening();
@@ -64,6 +65,7 @@ int main(int argc, char** argv)
 
         delete server;
         delete client;
+        delete httpClient;
 
         cout << argv[0] << " passed" << endl;
 
@@ -73,6 +75,7 @@ int main(int argc, char** argv)
         cerr << "Exception occured: " << e.what() << endl;
         delete server;
         delete client;
+        delete httpClient;
         return -999;
     }
 }

--- a/src/test/remotecounter.cpp
+++ b/src/test/remotecounter.cpp
@@ -20,7 +20,8 @@ int main(int argc, char** argv)
 {
 
     TestServer* server = new TestServer();
-    Client* client = new Client(new HttpClient("http://localhost:8080"));
+    HttpClient *httpClient = new HttpClient("http://localhost:8080");
+    Client* client = new Client(httpClient);
 
     try {
         server->StartListening();
@@ -44,6 +45,7 @@ int main(int argc, char** argv)
 
         delete server;
         delete client;
+        delete httpClient;
 
         cout << argv[0] << " passed" << endl;
 
@@ -53,6 +55,7 @@ int main(int argc, char** argv)
         cerr << "Exception occured: " << e.what() << endl;
         delete server;
         delete client;
+        delete httpClient;
         return -999;
     }
 }


### PR DESCRIPTION
You should not free something you didn't have allocated.

If you really want to keep the `delete` here to have a shorter syntax to create a new `Client`, you should change its value to `nullptr`.
In this case, the `delete` operation will be safe.

We have created a library which uses `libjson-rpc-cpp`, but because we allocate a new object in memory, we should free it ourself, `libjson-rpc-cpp` should not do it for us.
https://github.com/mage/mage-sdk-cpp/pull/14
