### PR TITLE
ADD: Tcp connector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,21 @@ cmake_minimum_required(VERSION 2.6)
 project(libjson-rpc-cpp)
 
 SET(HTTP_CONNECTOR YES CACHE BOOL "Include HTTP connector inside library")
+SET(SOCKET_CONNECTOR NO CACHE BOOL "Include simple SOCKET connector inside library")
 SET(STUB_GENERATOR YES CACHE BOOL "Build stub generator")
+
+if (HTTP_CONNECTOR OR SOCKET_CONNECTOR)
+  find_package(Threads REQUIRED)
+endif()
 
 if (HTTP_CONNECTOR)
   find_package(CURL REQUIRED)
   include_directories(${CURL_INCLUDE_DIRS})
   ADD_DEFINITIONS(-DHTTP_CONNECTOR)
+endif()
+
+if (SOCKET_CONNECTOR)
+  ADD_DEFINITIONS(-DSOCKET_CONNECTOR)
 endif()
 
 include_directories(${CMAKE_SOURCE_DIR}/src)

--- a/src/jsonrpc/CMakeLists.txt
+++ b/src/jsonrpc/CMakeLists.txt
@@ -1,21 +1,23 @@
 file(GLOB jsonrpc_source *.cpp json/*.c*)
 file(GLOB jsonrpc_header *.h)
 
-set(JSONRPC_DEPENDENCIES)
+
+set(JSONRPC_DEPENDENCIES ${CMAKE_THREAD_LIBS_INIT})
 
 if(HTTP_CONNECTOR)
 	file(GLOB connector_mongoose_source connectors/mongoose*.c*)
 	file(GLOB connector_mongoose_header connectors/mongoose*.h)
 	file(GLOB connector_http_source connectors/http*.c*)
 	file(GLOB connector_http_header connectors/http*.h)
-	set(JSONRPC_DEPENDENCIES ${JSONRPC_DEPENDENCIES} ${CURL_LIBRARIES} pthread dl)
+	set(JSONRPC_DEPENDENCIES ${JSONRPC_DEPENDENCIES} ${CURL_LIBRARIES} dl)
 endif()
 
-file(GLOB jsoncpp_header json/*.h)
+if(SOCKET_CONNECTOR)
+	file(GLOB connector_socket_source connectors/socket*.c*)
+	file(GLOB connector_socket_header connectors/socket*.h)
+endif()
 
-set(connectors_source ${connector_http_source} ${connector_mongoose_source})
-set(connectors_header ${connector_http_header} ${connector_mongoose_header})
-
+set(connectors_source ${connector_http_source} ${connector_mongoose_source} ${connector_socket_source})
 
 add_library(jsonrpc SHARED ${jsonrpc_source} ${connectors_source})
 add_library(jsonrpcStatic STATIC ${jsonrpc_source} ${connectors_source})
@@ -33,10 +35,14 @@ target_link_libraries(jsonrpcStatic ${JSONRPC_DEPENDENCIES})
 install(FILES ${jsonrpc_header} DESTINATION include/jsonrpc)
 install(FILES ${jsoncpp_header} DESTINATION include/jsonrpc/json)
 if(HTTP_CONNECTOR)
-	install(FILES ${connectors_header} DESTINATION include/jsonrpc/connectors)
+	install(FILES $${connector_http_header} ${connector_mongoose_header} DESTINATION include/jsonrpc/connectors)
+endif()
+if(SOCKET_CONNECTOR)
+	install(FILES ${connector_socket_header} DESTINATION include/jsonrpc/connectors)
 endif()
 
-install(TARGETS jsonrpc jsonrpcStatic LIBRARY DESTINATION lib
-                      ARCHIVE DESTINATION lib
-                      RUNTIME DESTINATION bin)
+install(TARGETS jsonrpc jsonrpcStatic
+					LIBRARY DESTINATION lib
+					ARCHIVE DESTINATION lib
+					RUNTIME DESTINATION bin)
 

--- a/src/jsonrpc/connectors/socket.h
+++ b/src/jsonrpc/connectors/socket.h
@@ -1,0 +1,15 @@
+#ifndef JSONRPC_CONNECTORS_SOCKET_H_
+#define JSONRPC_CONNECTORS_SOCKET_H_
+
+#define CHECK(status) if ((status) < 0) goto error;
+#define CHECK_PTR(ptr) if ((ptr) == NULL) goto error;
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+
+
+
+#endif // JSONRPC_CONNECTORS_SOCKET_H_

--- a/src/jsonrpc/connectors/socketclient.cpp
+++ b/src/jsonrpc/connectors/socketclient.cpp
@@ -1,0 +1,62 @@
+#include <string>
+#include <cstring>
+#include <unistd.h>
+
+#include "socketclient.h"
+
+
+namespace jsonrpc {
+
+  SocketClient::SocketClient(const std::string& url, const std::string& port, const int type) throw (JsonRpcException) :
+      AbstractClientConnector()
+  {
+    int p = std::stoi(port);
+    int family = AF_INET;
+    server_info_.sin_port = htons(p);
+    server_info_.sin_family = family;
+    server_info_.sin_addr.s_addr = inet_addr(url.c_str());
+    if (server_info_.sin_addr.s_addr == -1) {
+      struct hostent *he;
+      struct in_addr **addr_list;
+
+      CHECK_PTR((he = gethostbyname(url.c_str())));
+
+      addr_list = (struct in_addr **) he->h_addr_list;
+
+      for(int i = 0; addr_list[i] != NULL; i++) {
+        server_info_.sin_addr = *addr_list[i];
+        break;
+      }
+    }
+
+    socket_ = socket(family, type, 0);
+    CHECK(socket_);
+    return;
+
+error:
+    if (socket_ != -1)
+      close(socket_);
+    throw JsonRpcException(Errors::ERROR_CLIENT_CONNECTOR);
+  }
+
+  SocketClient::~SocketClient()
+  {
+      close(socket_);
+  }
+
+  void SocketClient::SendMessage(const std::string& message, std::string& result) throw (JsonRpcException) {
+    int read_size;
+    const int MAX_SIZE = 5000;
+    char server_message[MAX_SIZE];
+    memset(server_message, 0, MAX_SIZE);
+    connect(socket_, (struct sockaddr *)&server_info_ , sizeof(server_info_));
+    CHECK(write(socket_, message.c_str(), message.length()));
+    CHECK((read_size = read(socket_, server_message, MAX_SIZE)));
+    server_message[read_size] = '\0';
+    result.assign(server_message);
+    return;
+error:
+    throw JsonRpcException(Errors::ERROR_CLIENT_CONNECTOR);
+  }
+
+}

--- a/src/jsonrpc/connectors/socketclient.h
+++ b/src/jsonrpc/connectors/socketclient.h
@@ -1,0 +1,35 @@
+/*************************************************************************
+ * libjson-rpc-cpp
+ *************************************************************************
+ * @file    socketclient.h
+ * @date    12.07.2014
+ * @author  Bertrand Cachet <bertrand.cachet@gmail.com>
+ * @license See attached LICENSE.txt
+ ************************************************************************/
+#ifndef JSONRPC_CONNECTORS_SOCKETCLIENT_H
+#define JSONRPC_CONNECTORS_SOCKETCLIENT_H
+
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "../clientconnector.h"
+#include "../exception.h"
+#include "socket.h"
+
+namespace jsonrpc
+{
+  class SocketClient : public AbstractClientConnector
+  {
+    public:
+      SocketClient(const std::string& url = "localhost", const std::string& port = "8080", const int type = SOCK_STREAM) throw (JsonRpcException);
+      virtual ~SocketClient();
+
+      virtual void SendMessage(const std::string& message, std::string& result) throw (JsonRpcException);
+    private:
+      int socket_;
+      struct sockaddr_in server_info_;
+  };
+} // namespace jsonrpc
+
+#endif /* JSONRPC_CONNECTORS_SOCKETCLIENT_H*/

--- a/src/jsonrpc/connectors/socketserver.cpp
+++ b/src/jsonrpc/connectors/socketserver.cpp
@@ -1,0 +1,145 @@
+#include <cstring>
+#include <unistd.h>
+#include <pthread.h>
+#include <netdb.h>
+#include <vector>
+
+#include "socketserver.h"
+
+int set_socket_receive_timeout_ms(const int socketfd, const int timeout_ms) {
+    struct timeval timeout;
+    timeout.tv_sec = 0;
+    timeout.tv_usec = timeout_ms*1000;
+    return setsockopt(socketfd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeval));
+}
+
+namespace jsonrpc {
+    void CloseAllConnections(std::vector<SocketServer::Connection>& clients) {
+        for(std::vector<SocketServer::Connection>::const_iterator it = clients.cbegin(); it != clients.cend(); ++it ) {
+            close(it->socket);
+            pthread_join(it->thread, NULL);
+        }
+        clients.clear();
+    }
+    
+    void CloseFinishedConnections(std::vector<SocketServer::Connection>& clients) {
+        std::vector<SocketServer::Connection>::const_iterator it = clients.cbegin();
+        while (it != clients.cend()) {
+            if (it->finished) {
+                close(it->socket);
+                pthread_join(it->thread, NULL);
+                it = clients.erase(it);
+            }
+            else
+                ++it;
+        }
+    }
+
+
+  SocketServer::SocketServer(const std::string& port, const int type, const int pool) throw (JsonRpcException) :
+    AbstractServerConnector(),
+    host_info_(NULL),
+    shutdown_(false),
+    poolSize_(pool)
+  {
+    struct addrinfo hint;
+    memset((char*)&hint, 0, sizeof(addrinfo));
+    hint.ai_family = AF_INET;
+    hint.ai_socktype = type;
+    hint.ai_flags = AI_PASSIVE;
+    CHECK(getaddrinfo(NULL, port.c_str(), &hint, &host_info_));
+    return;
+error:
+    throw JsonRpcException(Errors::ERROR_SERVER_CONNECTOR);
+  }
+
+  SocketServer::~SocketServer()
+  {
+    StopListening();
+    if (host_info_ != NULL)
+      freeaddrinfo(host_info_);
+    host_info_ = NULL;
+
+  }
+
+  bool SocketServer::StartListening()
+  {
+    CreateSocket();
+    return pthread_create(&server_thread_, NULL, HandleConnections, this) == 0;
+  }
+
+  bool SocketServer::StopListening()
+  {
+    shutdown_ = true;
+    CloseSocket();
+    return true;
+  }
+
+  bool SocketServer::SendResponse( const std::string& response,
+                                void* addInfo)
+  {
+    Connection* connection = (Connection*)addInfo;
+    return write(connection->socket, response.c_str(), response.length()) == response.length();
+  }
+
+  void* SocketServer::HandleConnections(void* data) {
+    SocketServer* server = (SocketServer*) data;
+    std::vector<SocketServer::Connection> clients;
+    struct sockaddr_storage client_addr;
+    socklen_t addr_size = sizeof(sockaddr_storage);
+    server->shutdown_ = false;
+    while (!server->shutdown_) {
+      Connection client;
+      if ((client.socket = accept(server->socket_, (struct sockaddr*)&client_addr, &addr_size)) > 0) {
+        client.pserver = server;
+//        set_socket_receive_timeout_ms(client.socket, 500);
+        CloseFinishedConnections(clients);
+        if (clients.size() >= server->poolSize_) {
+            close(clients.front().socket);
+            pthread_join(clients.front().thread, NULL);
+            clients.erase(clients.begin());
+        }
+        clients.push_back(client);
+        pthread_create(&clients.back().thread, NULL, ConnectionHandler, &clients.back());
+      }
+    }
+    CloseAllConnections(clients);
+    close(server->socket_);
+    return 0;
+  }
+
+  void* SocketServer::ConnectionHandler(void* data) {
+    Connection* connection = (Connection*)data;
+    const int MAX_SIZE = 5000;
+    char client_message[MAX_SIZE];
+    int read_size;
+    connection->finished = false;
+    while((read_size = read(connection->socket , client_message , MAX_SIZE)) > 0) {
+      client_message[read_size] = '\0';
+      std::string request(client_message);
+      connection->pserver->OnRequest(request, connection);
+      memset(client_message, 0, MAX_SIZE);
+    }
+    connection->finished = true;
+    return 0;
+  }
+
+  void SocketServer::CreateSocket() {
+    int yes = 1;
+    socket_ = socket(host_info_->ai_family, host_info_->ai_socktype, host_info_->ai_protocol);
+    CHECK(socket_);
+    CHECK(setsockopt(socket_, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)));
+    CHECK(bind(socket_, host_info_->ai_addr, host_info_->ai_addrlen));
+    CHECK(listen(socket_, poolSize_));
+    return;
+error:
+    CloseSocket();
+  }
+
+  void SocketServer::CloseSocket() {
+    if (socket_ != -1)
+      close(socket_);
+    socket_ = -1;
+  }
+
+};

--- a/src/jsonrpc/connectors/socketserver.h
+++ b/src/jsonrpc/connectors/socketserver.h
@@ -1,0 +1,58 @@
+/*************************************************************************
+ * libjson-rpc-cpp
+ *************************************************************************
+ * @file    socketserver.h
+ * @date    12.07.2014
+ * @author  Bertrand Cachet <bertrand.cachet@gmail.com>
+ * @license See attached LICENSE.txt
+ ************************************************************************/
+#ifndef JSONRPC_SOCKET_SERVER_H_
+#define JSONRPC_SOCKET_SERVER_H_
+
+#include <string>
+#include <exception>
+
+#include "../serverconnector.h"
+#include "../exception.h"
+#include "socket.h"
+
+namespace jsonrpc {
+    
+  class SocketServer : public AbstractServerConnector {
+   public:
+      SocketServer(const std::string& port = "8080", const int type = SOCK_STREAM, const int pool = 1) throw (JsonRpcException);
+      ~SocketServer();
+
+      bool StartListening();
+      bool StopListening();
+
+      bool SendResponse(const std::string& response, void* addInfo = NULL);
+      
+      struct Connection {
+          int socket;
+          pthread_t thread;
+          SocketServer* pserver;
+          bool finished;
+      };
+    private:
+
+      pthread_t server_thread_;
+
+      int socket_;
+      struct addrinfo* host_info_;
+      bool shutdown_;
+      int poolSize_;
+
+      void CreateSocket();
+      void CloseSocket();
+//      void CloseAllConnections();
+//      void CloseOldConnections();
+
+      static void *ConnectionHandler(void *connection);
+      static void *HandleConnections(void* server);
+
+  };
+
+} // namespace jsonrpc
+
+#endif // JSONRPC_SOCKET_SERVER_H_

--- a/src/jsonrpc/rpc.h
+++ b/src/jsonrpc/rpc.h
@@ -21,6 +21,12 @@
   #include "connectors/httpclient.h"
 #endif
 
+#ifdef TCP_CONNECTOR
+  #include "connectors/socketserver.h"
+  #include "connectors/socketclient.h"
+#endif
+
+
 #include "specificationparser.h"
 #include "specificationwriter.h"
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -29,6 +29,12 @@ if (HTTP_CONNECTOR)
 	ADD_TEST(specification ${TEST_BINARIES}/specification)
 endif()
 
+if (SOCKET_CONNECTOR)
+	set(COMMON_SOURCES server.cpp)
+	add_executable(tcpconnector tcpconnector.cpp ${COMMON_SOURCES})
+	target_link_libraries(tcpconnector jsonrpc)
+  ADD_TEST(tcpconnector ${TEST_BINARIES}/tcpconnector)
+endif()
 
 add_executable(parametervalidation parametervalidation.cpp)
 target_link_libraries(parametervalidation jsonrpc)

--- a/src/test/server.cpp
+++ b/src/test/server.cpp
@@ -13,10 +13,26 @@
 using namespace std;
 using namespace jsonrpc;
 
-TestServer::TestServer() :
-    AbstractServer<TestServer>(new HttpServer(8080)),
-    cnt(0)
+TestServer::TestServer(AbstractServerConnector* connection) : AbstractServer<TestServer>(connection)
 {
+    initialize();
+}
+
+#if HTTP_CONNECTOR
+TestServer::TestServer() : AbstractServer<TestServer>(new HttpServer(8080))
+{
+    initialize();
+}
+#elif TCP_CONNETOR
+TestServer::TestServer() : AbstractServer<TestServer>(new TcpServer("8080"))
+{
+    initialize();
+}
+#endif
+
+void TestServer::initialize()
+{
+    cnt = 0;
     cout << "Called default const" << endl;
     this->bindAndAddMethod(new Procedure("sayHello", PARAMS_BY_NAME, JSON_STRING, "name", JSON_STRING, NULL), &TestServer::sayHello);
     this->bindAndAddMethod(new Procedure("getCounterValue", PARAMS_BY_NAME, JSON_INTEGER, NULL), &TestServer::getCounterValue);
@@ -25,6 +41,7 @@ TestServer::TestServer() :
 
     this->bindAndAddNotification(new Procedure("initCounter", PARAMS_BY_NAME, "value", JSON_INTEGER, NULL), &TestServer::initCounter);
     this->bindAndAddNotification(new Procedure("incrementCounter", PARAMS_BY_NAME, "value", JSON_INTEGER, NULL), &TestServer::incrementCounter);
+
 }
 
 void TestServer::sayHello(const Json::Value &request, Json::Value& response)

--- a/src/test/server.h
+++ b/src/test/server.h
@@ -13,11 +13,11 @@
 #include <jsonrpc/rpc.h>
 
 //Methods
-
     class TestServer : public jsonrpc::AbstractServer<TestServer>
     {
         public:
             TestServer();
+            TestServer(jsonrpc::AbstractServerConnector* connection);
 
             void sayHello(const Json::Value& request, Json::Value& response);
             void getCounterValue(const Json::Value& request, Json::Value& response);
@@ -29,6 +29,8 @@
             void incrementCounter(const Json::Value& request);
         private:
             int cnt;
+            void initialize();
+
     };
 
 #endif // SERVER_H

--- a/src/test/tcpconnector.cpp
+++ b/src/test/tcpconnector.cpp
@@ -1,0 +1,67 @@
+/*************************************************************************
+ * libjson-rpc-cpp
+ *************************************************************************
+ * @file    tcpconnector.cpp
+ * @date    07.10.2014
+ * @author  Bertrand Cachet <bertrand.cachet@gmail.com>
+ * @license See attached LICENSE.txt
+ ************************************************************************/
+
+#include <stdio.h>
+#include <string>
+#include <iostream>
+
+#include "server.h"
+#include <jsonrpc/procedure.h>
+#include <jsonrpc/specificationwriter.h>
+#include <jsonrpc/connectors/socketserver.h>
+#include <jsonrpc/connectors/socketclient.h>
+
+using namespace jsonrpc;
+using namespace std;
+
+int main(int argc, char** argv)
+{
+    SocketServer* connector = new SocketServer("8080", SOCK_STREAM, 2);
+    TestServer* server = new TestServer(connector);
+    Client* client = new Client(new SocketClient("localhost", "8080"));
+    Client* client2 = new Client(new SocketClient("localhost", "8080"));
+
+    cout << SpecificationWriter::toString(server->GetProtocolHanlder()->GetProcedures()) << endl;
+
+    try {
+        server->StartListening();
+
+        Json::Value v;
+        v["name"] = "Peter";
+        Json::Value result = client->CallMethod("sayHello", v);
+        Json::Value result2 = client2->CallMethod("sayHello", v);
+
+        if((result.asString() != "Hello: Peter!") && (result2.asString() != "Hello: Peter!")) {
+            cerr << "sayHello returned " << result.asString() << " but should be \"Hello: Peter!\"" << endl;
+            return -1;
+        }
+
+        v["name"] = "Peter Spiess-Knafl";
+        result = client->CallMethod("sayHello", v);
+        if(result.asString() != "Hello: Peter Spiess-Knafl!") {
+            cerr << "sayHello returned " << result.asString() << " but should be \"Hello: Peter Spiess-Knafl!\"" << endl;
+            return -2;
+        }
+
+        delete server;
+        delete client;
+        delete client2;
+
+        cout << argv[0] << " passed" << endl;
+
+        return 0;
+
+    } catch(jsonrpc::JsonRpcException e) {
+
+        cerr << "Exception occured: " << e.what() << endl;
+        delete server;
+        delete client;
+        return -999;
+    }
+}


### PR DESCRIPTION
# DONE
## Socket connectors
- Create SocketClient and SocketServer connectors that can be used for JSON-RPC via TCP socket (not really sure UDP is sufficient but can be activated).
  - Server can be configured to handle multiple connections at the same time. By default, it only handle one connection at a time.
  - Compilation of Socket connectors is conditioned with SOCKET_CONNECTOR CMake variable.
## Fix

I have corrected the way connectors headers are installed
## Improvement

Library dependency uppon pthread is integrated into CMake configuration using Threads package
# TODO

Refactor to use Windows thread instead of pthread on Windows platforms
