### PR TITLE
HTTP concurrency

### DIFF
--- a/src/jsonrpc/connectors/httpclient.cpp
+++ b/src/jsonrpc/connectors/httpclient.cpp
@@ -63,7 +63,15 @@ namespace jsonrpc
     HttpClient::HttpClient(const std::string& url) throw(JsonRpcException)
         : AbstractClientConnector(), url(url)
     {
-        curl = curl_easy_init();
+    }
+
+    HttpClient::~HttpClient()
+    {
+    }
+
+    void HttpClient::SendMessage(const std::string& message, std::string& result) throw (JsonRpcException)
+    {
+        CURL* curl = curl_easy_init();
         if (!curl)
         {
             throw JsonRpcException(Errors::ERROR_CLIENT_CONNECTOR, ": libcurl initialization error");
@@ -71,18 +79,7 @@ namespace jsonrpc
 
         curl_easy_setopt(curl, CURLOPT_URL, this->url.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, writefunc);
-    }
 
-    HttpClient::~HttpClient()
-    {
-        if (curl)
-        {
-            curl_easy_cleanup(curl);
-        }
-    }
-
-    void HttpClient::SendMessage(const std::string& message, std::string& result) throw (JsonRpcException)
-    {
         CURLcode res;
 
         struct string s;
@@ -120,12 +117,16 @@ namespace jsonrpc
             }
             throw JsonRpcException(Errors::ERROR_CLIENT_CONNECTOR, str.str());
         }
+
+        if (curl)
+        {
+            curl_easy_cleanup(curl);
+        }
     }
 
     void HttpClient::SetUrl(const std::string& url)
     {
         this->url = url;
-        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
     }
 
     void HttpClient::AddHeader(const std::string attr, const std::string val) {

--- a/src/jsonrpc/connectors/httpclient.h
+++ b/src/jsonrpc/connectors/httpclient.h
@@ -13,7 +13,6 @@
 #include "../clientconnector.h"
 #include "../exception.h"
 #include <map>
-#include <curl/curl.h>
 
 namespace jsonrpc
 {
@@ -34,7 +33,6 @@ namespace jsonrpc
         private:
             std::map<std::string,std::string> headers;
             std::string url;
-            CURL* curl;
     };
 
 } /* namespace jsonrpc */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -3,6 +3,29 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/out/test)
 
 if (HTTP_CONNECTOR)
 	set(COMMON_SOURCES server.cpp)
+
+	if (NOT("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND ${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+		include(CheckCXXCompilerFlag)
+		CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+		CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+		if(COMPILER_SUPPORTS_CXX11)
+			ADD_DEFINITIONS(-std=c++11)
+		elseif(COMPILER_SUPPORTS_CXX0X)
+			ADD_DEFINITIONS(-std=c++0x)
+		endif()
+
+		if (COMPILER_SUPPORTS_CXX11 OR COMPILER_SUPPORTS_CXX0X)
+			if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+				ADD_DEFINITIONS(-stdlib=libc++)
+			endif()
+
+			add_executable(concurrency concurrency.cpp ${COMMON_SOURCES})
+			target_link_libraries(concurrency jsonrpc)
+
+			ADD_TEST(concurrency ${TEST_BINARIES}/concurrency)
+		endif()
+	endif()
+
 	add_executable(helloworld helloworld.cpp ${COMMON_SOURCES})
 	target_link_libraries(helloworld jsonrpc)
 

--- a/src/test/concurrency.cpp
+++ b/src/test/concurrency.cpp
@@ -1,0 +1,83 @@
+/*************************************************************************
+ * libjson-rpc-cpp
+ *************************************************************************
+ * @file    concurrency.cpp
+ * @date    12.08.2014
+ * @author  Emilien Kenler <ekenler@wizcorp.jp>
+ * @license See attached LICENSE.txt
+ ************************************************************************/
+
+#include <stdio.h>
+#include <string>
+#include <iostream>
+
+#include "server.h"
+#include <jsonrpc/procedure.h>
+#include <jsonrpc/specificationwriter.h>
+#include <thread>
+
+using namespace jsonrpc;
+using namespace std;
+
+int main(int argc, char** argv)
+{
+
+    TestServer* server = new TestServer();
+    HttpClient *httpClient = new HttpClient("http://localhost:8080");
+    Client* client = new Client(httpClient);
+
+    cout << SpecificationWriter::toString(server->GetProtocolHanlder()->GetProcedures()) << endl;
+
+    try {
+        server->StartListening();
+
+        int error = 0;
+
+        std::thread t1 = std::thread([client,&error]{
+            Json::Value v;
+            v["name"] = "Peter";
+            Json::Value result = client->CallMethod("sayHello", v);
+
+            if(result.asString() != "Hello: Peter!") {
+                cerr << "sayHello returned " << result.asString() << " but should be \"Hello: Peter!\"" << endl;
+                error = -1;
+            }
+        });
+
+        std::thread t2 = std::thread([client,&error]{
+            Json::Value v;
+            v["name"] = "Peter Spiess-Knafl";
+            Json::Value result = client->CallMethod("sayHello", v);
+
+            if(result.asString() != "Hello: Peter Spiess-Knafl!") {
+                cerr << "sayHello returned " << result.asString() << " but should be \"Hello: Peter Spiess-Knafl!\"" << endl;
+                error = -2;
+            }
+        });
+
+        t1.join();
+        cout << "t1 joined" << endl;
+        t2.join();
+        cout << "t2 joined" << endl;
+
+        delete server;
+        delete client;
+        delete httpClient;
+
+        if (error < 0) {
+            return error;
+        }
+
+        cout << argv[0] << " passed" << endl;
+
+        return 0;
+
+    } catch(jsonrpc::JsonRpcException e) {
+
+        cerr << "Exception occured: " << e.what() << endl;
+        delete server;
+        delete client;
+        delete httpClient;
+        return -999;
+    }
+}


### PR DESCRIPTION
Creating a new curl session for each HTTP call allows to do multiple
call at the same time with the same client instance.

The test use C++11 `std::thread`.

Should solve the issues reported in https://github.com/mage/mage-sdk-cpp/pull/28
