### PR TITLE
FIX: Method name normalization in server stub generator

### DIFF
--- a/src/stubgenerator/serverstubgenerator.cpp
+++ b/src/stubgenerator/serverstubgenerator.cpp
@@ -56,6 +56,7 @@ string ServerStubGenerator::generateBindings()
         {
             tmp = TEMPLATE_SERVER_NOTIFICATIONBINDING;
         }
+        replaceAll(tmp, "<rpcprocedurename>", proc->GetProcedureName());
         replaceAll(tmp, "<procedurename>", normalizeString(proc->GetProcedureName()));
         replaceAll(tmp, "<returntype>", toString(proc->GetReturnType()));
         replaceAll(tmp, "<parameterlist>", generateBindingParameterlist(proc));
@@ -91,7 +92,7 @@ string ServerStubGenerator::generateProcedureDefinitions()
         {
             tmp = TEMPLATE_SERVER_NOTIFICAITONDEFINITION;
         }
-        replaceAll(tmp,"<procedurename>", proc->GetProcedureName());
+        replaceAll(tmp,"<procedurename>", normalizeString(proc->GetProcedureName()));
         replaceAll(tmp,"<parametermapping>", this->generateParameterMapping(proc));
         result << tmp << endl;
     }
@@ -114,7 +115,7 @@ string ServerStubGenerator::generateAbstractDefinitions()
             returntype = toCppType(proc->GetReturnType());
         }
         replaceAll(tmp, "<returntype>", returntype);
-        replaceAll(tmp, "<procedurename>", proc->GetProcedureName());
+        replaceAll(tmp, "<procedurename>", normalizeString(proc->GetProcedureName()));
         replaceAll(tmp, "<parameterlist>", generateParameterDeclarationList(*proc));
         result << tmp;
     }

--- a/src/stubgenerator/servertemplate.h
+++ b/src/stubgenerator/servertemplate.h
@@ -36,9 +36,9 @@ class <stubname> : public jsonrpc::AbstractServer<<stubname>>\n\
 "
 
 #define TEMPLATE_SERVER_METHODBINDING "\
-            this->bindAndAddMethod(new jsonrpc::Procedure(\"<procedurename>\", <paramtype>, <returntype>, <parameterlist> NULL), &<stubname>::<procedurename>I);"
+            this->bindAndAddMethod(new jsonrpc::Procedure(\"<rpcprocedurename>\", <paramtype>, <returntype>, <parameterlist> NULL), &<stubname>::<procedurename>I);"
 #define TEMPLATE_SERVER_NOTIFICATIONBINDING "\
-            this->bindAndAddNotification(new jsonrpc::Procedure(\"<procedurename>\", <paramtype>, <parameterlist> NULL), &<stubname>::<procedurename>I);"
+            this->bindAndAddNotification(new jsonrpc::Procedure(\"<rpcprocedurename>\", <paramtype>, <parameterlist> NULL), &<stubname>::<procedurename>I);"
 
 #define TEMPLATE_SERVER_METHODDEFINITION "\
         inline virtual void <procedurename>I(const Json::Value& request, Json::Value& response) \n\


### PR DESCRIPTION
This JSON file

``` json
[
    {
        "method": "foo.bar",
        "params": null,
        "returns" : {}
    }
]
```

was converted in 

``` cpp
this->bindAndAddMethod(new jsonrpc::Procedure("foo_bar", jsonrpc::PARAMS_BY_NAME, jsonrpc::JSON_OBJECT,  NULL), &AbstractFooBarServer::foo_barI);
inline virtual void foo_barI(const Json::Value& request, Json::Value& response) 
{
    response = this->foo.bar();
}
virtual Json::Value foo.bar() = 0;
```

Now conversion is 

``` cpp
this->bindAndAddMethod(new jsonrpc::Procedure("foo.bar", jsonrpc::PARAMS_BY_NAME, jsonrpc::JSON_OBJECT,  NULL), &AbstractFooBarServer::foo_barI);
inline virtual void foo_barI(const Json::Value& request, Json::Value& response) 
{
    response = this->foo_bar();
}
virtual Json::Value foo_bar() = 0;
```
