### PR TITLE
Support passing port as string to HttpServer

### DIFF
--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -12,6 +12,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cstring>
+#include <sstream>
 
 using namespace jsonrpc;
 
@@ -58,6 +59,19 @@ int HttpServer::callback(struct mg_connection *conn)
 
 HttpServer::HttpServer(int port, bool enableSpecification, const std::string &sslcert, int threads) :
     AbstractServerConnector(),
+    ctx(NULL),
+    running(false),
+    showSpec(enableSpecification),
+    sslcert(sslcert),
+    threads(threads)
+{
+    std::stringstream ss;
+    ss << port;
+    this->port = ss.str();
+}
+
+HttpServer::HttpServer(const std::string &port, bool enableSpecification, const std::string &sslcert, int threads) :
+    AbstractServerConnector(),
     port(port),
     ctx(NULL),
     running(false),
@@ -71,24 +85,22 @@ bool HttpServer::StartListening()
 {
     if(!this->running)
     {
-        char port[6];
         char threads[6];
         struct mg_callbacks callbacks;
         memset(&callbacks, 0, sizeof(callbacks));
         callbacks.begin_request = callback;
 
-        sprintf(port, "%d", this->port);
         sprintf(threads, "%d", this->threads);
 
         if(this->sslcert == "")
         {
-            const char *options[] = { "listening_ports", port, "num_threads", threads, NULL };
+            const char *options[] = { "listening_ports", this->port.c_str(), "num_threads", threads, NULL };
             this->ctx = mg_start(&callbacks, this, options);
         }
         else
         {
             const char *options[] =
-            { "listening_ports", port, "ssl_certificate", this->sslcert.c_str(), "num_threads", threads, NULL };
+            { "listening_ports", this->port.c_str(), "ssl_certificate", this->sslcert.c_str(), "num_threads", threads, NULL };
             this->ctx = mg_start(&callbacks, this, options);
         }
 

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -32,6 +32,7 @@ namespace jsonrpc
              * @param sslcert - defines the path to a SSL certificate, if this path is != "", then SSL/HTTPS is used with the given certificate.
              */
             HttpServer(int port, bool enableSpecification = true, const std::string& sslcert = "", int threads = 50);
+            HttpServer(const std::string& port, bool enableSpecification = true, const std::string& sslcert = "", int threads = 50);
 
             virtual bool StartListening();
             virtual bool StopListening();
@@ -40,7 +41,7 @@ namespace jsonrpc
                     void* addInfo = NULL);
 
         private:
-            int port;
+            std::string port;
             struct mg_context *ctx;
             bool running;
             bool showSpec;


### PR DESCRIPTION
According to the mongoose documentation, any port on which you want to enable SSL must have an s appended to it. Currently, the port is passed as an integer to the HttpServer constructor despite the fact that the mongoose API expects a c string.

I added a second constructor that takes a string for the port . This allows one to pass a comma-delimited list of ports and to specify which are to use ssl. Furthermore, the port is now a string member of the class. 

For backwards compatibility, the original constructor prototype is kept as well.

// example
HttpServer server("80,443s", true, "my-cert.pem");
