### PR TITLE
jsonrpcstub --version

### DIFF
--- a/src/stubgenerator/stubgeneratorfactory.cpp
+++ b/src/stubgenerator/stubgeneratorfactory.cpp
@@ -9,6 +9,7 @@
 
 #include "stubgeneratorfactory.h"
 #include <jsonrpccpp/common/specificationparser.h>
+#include <jsonrpccpp/version.h>
 #include <iostream>
 #include <argtable2.h>
 #include "helper/cpphelper.h"
@@ -23,6 +24,7 @@ bool StubGeneratorFactory::createStubGenerators(int argc, char **argv, vector<Pr
 {
     struct arg_file *inputfile      = arg_file0(NULL, NULL, "<specfile>", "path of input specification file");
     struct arg_lit *help            = arg_lit0("h","help", "print this help and exit");
+    struct arg_lit *version         = arg_lit0(NULL,"version", "print version and exit");
     struct arg_lit *verbose         = arg_lit0("v","verbose", "print more information about what is happening");
     struct arg_str *cppserver       = arg_str0(NULL, "cpp-server", "<namespace::classname>", "name of the C++ server stub class");
     struct arg_str *cppserverfile   = arg_str0(NULL, "cpp-server-file", "<filename.h>", "name of the C++ server stub file");
@@ -33,7 +35,7 @@ bool StubGeneratorFactory::createStubGenerators(int argc, char **argv, vector<Pr
 
 
     struct arg_end *end         = arg_end(20);
-    void* argtable[] = {inputfile, help, verbose, cppserver, cppserverfile, cppclient, cppclientfile, jsclient, jsclientfile,end};
+    void* argtable[] = {inputfile, help, version, verbose, cppserver, cppserverfile, cppclient, cppclientfile, jsclient, jsclientfile,end};
 
     if (arg_parse(argc,argv,argtable) > 0)
     {
@@ -48,6 +50,12 @@ bool StubGeneratorFactory::createStubGenerators(int argc, char **argv, vector<Pr
         arg_print_syntax(stdout,argtable,"\n"); cout << endl;
         arg_print_glossary_gnu(stdout, argtable);
         arg_freetable(argtable,sizeof(argtable)/sizeof(argtable[0]));
+        return true;
+    }
+
+    if (version->count > 0)
+    {
+        cout << 'v' << JSONRPC_CPP_MAJOR_VERSION << '.' << JSONRPC_CPP_MINOR_VERSION << '.' << JSONRPC_CPP_PATCH_VERSION << endl;
         return true;
     }
 

--- a/src/stubgenerator/stubgeneratorfactory.cpp
+++ b/src/stubgenerator/stubgeneratorfactory.cpp
@@ -55,7 +55,8 @@ bool StubGeneratorFactory::createStubGenerators(int argc, char **argv, vector<Pr
 
     if (version->count > 0)
     {
-        cout << 'v' << JSONRPC_CPP_MAJOR_VERSION << '.' << JSONRPC_CPP_MINOR_VERSION << '.' << JSONRPC_CPP_PATCH_VERSION << endl;
+        cout << "jsonrpcstub version " << JSONRPC_CPP_MAJOR_VERSION << '.' << JSONRPC_CPP_MINOR_VERSION << '.' << JSONRPC_CPP_PATCH_VERSION << endl;
+        arg_freetable(argtable,sizeof(argtable)/sizeof(argtable[0]));
         return true;
     }
 

--- a/src/test/test_stubgenerator.cpp
+++ b/src/test/test_stubgenerator.cpp
@@ -112,6 +112,17 @@ BOOST_AUTO_TEST_CASE(test_stubgen_factory_help)
     BOOST_CHECK_EQUAL(procedures.empty(), true);
 }
 
+BOOST_AUTO_TEST_CASE(test_stubgen_factory_version)
+{
+    vector<StubGenerator*> stubgens;
+    vector<Procedure> procedures;
+    const char* argv[2] = {"jsonrpcstub","--version"};
+
+    BOOST_CHECK_EQUAL(StubGeneratorFactory::createStubGenerators(2, (char**)argv, procedures, stubgens), true);
+    BOOST_CHECK_EQUAL(stubgens.empty(), true);
+    BOOST_CHECK_EQUAL(procedures.empty(), true);
+}
+
 BOOST_AUTO_TEST_CASE(test_stubgen_factory_error)
 {
     vector<StubGenerator*> stubgens;


### PR DESCRIPTION
printing jsonrpcstub version.

In our project ([ethereum](https://github.com/ethereum/cpp-ethereum)), we are using jsonrpcstub as a part cmake build process. It would be helpful to know, what version of jsonrpcstub is installed on user machine.