### PR TITLE
Fixed msvc build, appveyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -60,8 +60,7 @@ before_build:
     - cmake -E copy_directory jsoncpp install
 
     # argtable not supported
-
-    - ls
+   
     - echo "Running cmake..."
     - cd c:\projects\libjson-rpc-cpp
     - cmake -DCMAKE_PREFIX_PATH="c:/projects/libjson-rpc-cpp/deps/install" -DCOMPILE_STUBGEN=NO .
@@ -70,6 +69,12 @@ build:
     project: ALL_BUILD.vcxproj      # path to Visual Studio solution or project
 
 after_build:
+      # copy missing dlls
+    - cd c:\projects\libjson-rpc-cpp\bin\Debug
+    - cmake -E copy c:\projects\libjson-rpc-cpp\deps\install\bin\libmicrohttpd-dll_d.dll .
+
+      # run tests
     - echo "Running tests..."
+    - unit_testsuite.exe
     - echo "Finished!"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,75 @@
+version: 0.5.0.{build}
+
+branches:
+    only:
+        - master
+        - develop
+
+os: Windows Server 2012 R2
+
+clone_folder: c:\projects\libjson-rpc-cpp
+
+#platform: Any CPU
+#configuration: Debug
+
+install:
+    # by default, all script lines are interpreted as batch
+
+# scripts to run before build
+before_build:
+
+    # setup dependency directory
+    - mkdir c:\projects\libjson-rpc-cpp\deps
+    - mkdir c:\projects\libjson-rpc-cpp\deps\install
+    - cd c:\projects\libjson-rpc-cpp\deps
+
+    # get boost
+    - echo "Downloading boost..."
+    - curl -O https://build.ethdev.com/builds/windows-precompiled/boost.tar.gz
+    - echo "Unzipping boost..."
+    - 7z x boost.tar.gz > nul
+    - 7z x boost.tar > nul
+    - echo "boost unzipped!"
+    - cmake -E copy_directory boost install
+
+    # get curl
+    - echo "Downloading curl..."
+    - curl -O https://build.ethdev.com/builds/windows-precompiled/curl.tar.gz
+    - echo "Unzipping curl..."
+    - 7z x curl.tar.gz > nul
+    - 7z x curl.tar > nul
+    - echo "curl unzipped!"
+    - cmake -E copy_directory curl install
+    
+    # get microhttpd
+    - echo "Downloading microhttpd..."
+    - curl -O https://build.ethdev.com/builds/windows-precompiled/microhttpd.tar.gz
+    - echo "Unzipping microhttpd..."
+    - 7z x microhttpd.tar.gz > nul
+    - 7z x microhttpd.tar > nul
+    - echo "microhttpd unzipped!"
+    - cmake -E copy_directory microhttpd install
+
+    # get jsoncpp
+    - echo "Downloading jsoncpp..."
+    - curl -O https://build.ethdev.com/builds/windows-precompiled/jsoncpp.tar.gz
+    - echo "Unzipping jsoncpp..."
+    - 7z x jsoncpp.tar.gz > nul
+    - 7z x jsoncpp.tar > nul
+    - echo "jsoncpp unzipped!"
+    - cmake -E copy_directory jsoncpp install
+
+    # argtable not supported
+
+    - ls
+    - echo "Running cmake..."
+    - cd c:\projects\libjson-rpc-cpp
+    - cmake -DCMAKE_PREFIX_PATH="c:/projects/libjson-rpc-cpp/deps/install" -DCOMPILE_STUBGEN=NO .
+
+build:
+    project: ALL_BUILD.vcxproj      # path to Visual Studio solution or project
+
+after_build:
+    - echo "Running tests..."
+    - echo "Finished!"
+

--- a/src/jsonrpccpp/CMakeLists.txt
+++ b/src/jsonrpccpp/CMakeLists.txt
@@ -65,7 +65,7 @@ target_link_libraries(jsonrpccommon ${JSONCPP_LIBRARIES})
 set_target_properties(jsonrpccommon PROPERTIES OUTPUT_NAME jsonrpccpp-common)
 
 # setup static common library
-if (BUILD_STATIC_LIBS)
+if (BUILD_STATIC_LIBS OR MSVC)
 	add_library(jsonrpccommonStatic STATIC ${jsonrpc_source_common} ${jsonrpc_header} ${jsonrpc_helper_source_common})
 	target_link_libraries(jsonrpccommonStatic ${JSONCPP_LIBRARIES})
 	set_target_properties(jsonrpccommonStatic PROPERTIES OUTPUT_NAME jsonrpccpp-common)
@@ -73,33 +73,33 @@ endif()
 
 # setup shared client library
 add_library(jsonrpcclient SHARED ${jsonrpc_source_client} ${jsonrpc_header} ${jsonrpc_header_client} ${client_connector_source})
-add_dependencies(jsonrpcclient jsonrpccommon)
 target_link_libraries(jsonrpcclient jsonrpccommon ${client_connector_libs})
 set_target_properties(jsonrpcclient PROPERTIES OUTPUT_NAME jsonrpccpp-client)
 
 # setup static client library
-if (BUILD_STATIC_LIBS)
+if (BUILD_STATIC_LIBS OR MSVC)
 	add_library(jsonrpcclientStatic STATIC ${jsonrpc_source_client} ${jsonrpc_header} ${jsonrpc_header_client} ${client_connector_source})
 	target_link_libraries(jsonrpcclientStatic jsonrpccommonStatic ${client_connector_libs})
 	set_target_properties(jsonrpcclientStatic PROPERTIES OUTPUT_NAME jsonrpccpp-client)
+	add_dependencies(jsonrpcclient jsonrpccommonStatic)
 endif()
 
 # setup shared server library
 add_library(jsonrpcserver SHARED ${jsonrpc_source_server} ${jsonrpc_header} ${jsonrpc_header_server} ${server_connector_source})
-add_dependencies(jsonrpcserver jsonrpccommon)
 target_link_libraries(jsonrpcserver jsonrpccommon ${server_connector_libs})
 set_target_properties(jsonrpcserver PROPERTIES OUTPUT_NAME jsonrpccpp-server)
 
 # setup static server library
-if (BUILD_STATIC_LIBS)
+if (BUILD_STATIC_LIBS OR MSVC)
 	add_library(jsonrpcserverStatic STATIC ${jsonrpc_source_server} ${jsonrpc_header} ${jsonrpc_header_server} ${server_connector_source})
 	target_link_libraries(jsonrpcserverStatic jsonrpccommonStatic ${server_connector_libs})
 	set_target_properties(jsonrpcserverStatic PROPERTIES OUTPUT_NAME jsonrpccpp-server)
+	add_dependencies(jsonrpcserver jsonrpccommonStatic)
 endif()
 
 set(ALL_LIBS jsonrpccommon jsonrpcclient jsonrpcserver)
 
-if (BUILD_STATIC_LIBS)
+if (BUILD_STATIC_LIBS OR MSVC)
 	list(APPEND ALL_LIBS jsonrpccommonStatic jsonrpcclientStatic jsonrpcserverStatic)
 endif()
 


### PR DESCRIPTION
**Changes:**
- fixed windows build (msvc likes static?)
- current continues integration status for windows is here https://ci.appveyor.com/project/debris/libjson-rpc-cpp

Library is building properly, but some tests are not passing. I Hope we can have this pr merged asap to avoid breaking windows build in future.

**appveyor.yml** Is using *[ethereum's](https://github.com/ethereum)* integration server to download dependencies. Please change location of this files.