### PR TITLE
Adding listen only to loopback feature for http server

### DIFF
--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -161,6 +161,7 @@ bool HttpServer::StopListening()
     if(this->running)
     {
         MHD_stop_daemon(this->daemon);
+        close(this->sockfd);
         this->running = false;
     }
     return true;

--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -26,11 +26,12 @@ struct mhd_coninfo {
         int code;
 };
 
-HttpServer::HttpServer(int port, const std::string &sslcert, const std::string &sslkey, int threads) :
+HttpServer::HttpServer(int port, const bool listenOnlyToLoopback, const std::string &sslcert, const std::string &sslkey, int threads) :
     AbstractServerConnector(),
     port(port),
     threads(threads),
     running(false),
+    listenOnlyToLoopback(listenOnlyToLoopback),
     path_sslcert(sslcert),
     path_sslkey(sslkey),
     daemon(NULL)
@@ -57,7 +58,52 @@ bool HttpServer::StartListening()
                 SpecificationParser::GetFileContent(this->path_sslcert, this->sslcert);
                 SpecificationParser::GetFileContent(this->path_sslkey, this->sslkey);
 
-                this->daemon = MHD_start_daemon(MHD_USE_SSL | MHD_USE_SELECT_INTERNALLY, this->port, NULL, NULL, HttpServer::callback, this, MHD_OPTION_HTTPS_MEM_KEY, this->sslkey.c_str(), MHD_OPTION_HTTPS_MEM_CERT, this->sslcert.c_str(), MHD_OPTION_THREAD_POOL_SIZE, this->threads, MHD_OPTION_END);
+                if(this->listenOnlyToLoopback) {
+                    this->sockfd = socket(AF_INET, SOCK_STREAM, 0);
+                    if(this->sockfd < 0)
+                        cerr << "can't open stream socket" << endl;
+                    
+                    this->addr.sin_family = AF_INET;
+                    this->addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+                    this->addr.sin_port = htons(this->port);
+
+                    if (bind(this->sockfd, (struct sockaddr *) &(this->addr), sizeof(this->addr)) < 0)
+                        cerr << "server: can't bind local address" << endl;
+
+                    listen(sockfd, 5);
+                    cout << "Using own socket (" << this->addr.sin_addr.s_addr << ", " << this->addr.sin_port << ")" << endl;
+
+                    this->daemon = MHD_start_daemon(MHD_USE_SSL | MHD_USE_SELECT_INTERNALLY,
+                                                    this->port,
+                                                    NULL,
+                                                    NULL,
+                                                    HttpServer::callback,
+                                                    this,
+                                                    MHD_OPTION_HTTPS_MEM_KEY,
+                                                    this->sslkey.c_str(),
+                                                    MHD_OPTION_HTTPS_MEM_CERT,
+                                                    this->sslcert.c_str(),
+                                                    MHD_OPTION_THREAD_POOL_SIZE,
+                                                    this->threads,
+                                                    MHD_OPTION_LISTEN_SOCKET,
+                                                    this->sockfd,
+                                                    MHD_OPTION_END);
+                }
+                else {
+                    this->daemon = MHD_start_daemon(MHD_USE_SSL | MHD_USE_SELECT_INTERNALLY,
+                                                    this->port,
+                                                    NULL,
+                                                    NULL,
+                                                    HttpServer::callback,
+                                                    this,
+                                                    MHD_OPTION_HTTPS_MEM_KEY,
+                                                    this->sslkey.c_str(),
+                                                    MHD_OPTION_HTTPS_MEM_CERT,
+                                                    this->sslcert.c_str(),
+                                                    MHD_OPTION_THREAD_POOL_SIZE,
+                                                    this->threads,
+                                                    MHD_OPTION_END);
+                }
             }
             catch (JsonRpcException& ex)
             {
@@ -66,7 +112,51 @@ bool HttpServer::StartListening()
         }
         else
         {
-            this->daemon = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY, this->port, NULL, NULL, HttpServer::callback, this,   MHD_OPTION_THREAD_POOL_SIZE, this->threads, MHD_OPTION_END);
+            if(this->listenOnlyToLoopback) {
+                this->sockfd = socket(AF_INET, SOCK_STREAM, 0);
+                if(this->sockfd < 0)
+                    cerr << "can't open stream socket" << endl;
+
+                this->addr.sin_family = AF_INET;
+                this->addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+                this->addr.sin_port = htons(this->port);
+
+                if (bind(this->sockfd, (struct sockaddr *) &(this->addr), sizeof(this->addr)) < 0)
+                    cerr << "server: can't bind local address" << endl;
+
+                listen(sockfd, 5);
+                
+                this->daemon = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY,
+                                                this->port,
+                                                NULL,
+                                                NULL,
+                                                HttpServer::callback,
+                                                this,
+                                                MHD_OPTION_HTTPS_MEM_KEY,
+                                                this->sslkey.c_str(),
+                                                MHD_OPTION_HTTPS_MEM_CERT,
+                                                this->sslcert.c_str(),
+                                                MHD_OPTION_THREAD_POOL_SIZE,
+                                                this->threads,
+                                                MHD_OPTION_LISTEN_SOCKET,
+                                                this->sockfd,
+                                                MHD_OPTION_END);
+            }
+            else {
+                this->daemon = MHD_start_daemon(MHD_USE_SELECT_INTERNALLY,
+                                                this->port,
+                                                NULL,
+                                                NULL,
+                                                HttpServer::callback,
+                                                this,
+                                                MHD_OPTION_HTTPS_MEM_KEY,
+                                                this->sslkey.c_str(),
+                                                MHD_OPTION_HTTPS_MEM_CERT,
+                                                this->sslcert.c_str(),
+                                                MHD_OPTION_THREAD_POOL_SIZE,
+                                                this->threads,
+                                                MHD_OPTION_END);
+            }
         }
         if (this->daemon != NULL)
             this->running = true;

--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -71,7 +71,6 @@ bool HttpServer::StartListening()
                         cerr << "server: can't bind local address" << endl;
 
                     listen(sockfd, 5);
-                    cout << "Using own socket (" << this->addr.sin_addr.s_addr << ", " << this->addr.sin_port << ")" << endl;
 
                     this->daemon = MHD_start_daemon(MHD_USE_SSL | MHD_USE_SELECT_INTERNALLY,
                                                     this->port,
@@ -132,10 +131,6 @@ bool HttpServer::StartListening()
                                                 NULL,
                                                 HttpServer::callback,
                                                 this,
-                                                MHD_OPTION_HTTPS_MEM_KEY,
-                                                this->sslkey.c_str(),
-                                                MHD_OPTION_HTTPS_MEM_CERT,
-                                                this->sslcert.c_str(),
                                                 MHD_OPTION_THREAD_POOL_SIZE,
                                                 this->threads,
                                                 MHD_OPTION_LISTEN_SOCKET,
@@ -149,10 +144,6 @@ bool HttpServer::StartListening()
                                                 NULL,
                                                 HttpServer::callback,
                                                 this,
-                                                MHD_OPTION_HTTPS_MEM_KEY,
-                                                this->sslkey.c_str(),
-                                                MHD_OPTION_HTTPS_MEM_CERT,
-                                                this->sslcert.c_str(),
                                                 MHD_OPTION_THREAD_POOL_SIZE,
                                                 this->threads,
                                                 MHD_OPTION_END);

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -49,7 +49,7 @@ namespace jsonrpc
              * @param enableSpecification - defines if the specification is returned in case of a GET request
              * @param sslcert - defines the path to a SSL certificate, if this path is != "", then SSL/HTTPS is used with the given certificate.
              */
-            HttpServer(int port, const bool listenOnlyToLoopback = true, const std::string& sslcert = "", const std::string& sslkey = "", int threads = 50);
+            HttpServer(int port, const bool listenOnlyToLoopback = false, const std::string& sslcert = "", const std::string& sslkey = "", int threads = 50);
 
             virtual bool StartListening();
             virtual bool StopListening();

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <ws2tcpip.h>
+#include <Wsk.h>
 #if defined(_MSC_FULL_VER) && !defined (_SSIZE_T_DEFINED)
 #define _SSIZE_T_DEFINED
 typedef intptr_t ssize_t;

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -23,6 +23,7 @@ typedef intptr_t ssize_t;
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #endif
 
 #include <map>
@@ -44,10 +45,11 @@ namespace jsonrpc
             /**
              * @brief HttpServer, constructor for the included HttpServer
              * @param port on which the server is listening
+             * @param listenOnlyToLoopback - defines if the server should only listen on loopback interface
              * @param enableSpecification - defines if the specification is returned in case of a GET request
              * @param sslcert - defines the path to a SSL certificate, if this path is != "", then SSL/HTTPS is used with the given certificate.
              */
-            HttpServer(int port, const std::string& sslcert = "", const std::string& sslkey = "", int threads = 50);
+            HttpServer(int port, const bool listenOnlyToLoopback = true, const std::string& sslcert = "", const std::string& sslkey = "", int threads = 50);
 
             virtual bool StartListening();
             virtual bool StopListening();
@@ -59,9 +61,12 @@ namespace jsonrpc
             void SetUrlHandler(const std::string &url, IClientConnectionHandler *handler);
 
         private:
+            int sockfd;
+            struct sockaddr_in addr;
             int port;
             int threads;
             bool running;
+            bool listenOnlyToLoopback;
             std::string path_sslcert;
             std::string path_sslkey;
             std::string sslcert;


### PR DESCRIPTION
Hello!

I implemented a (quick) way to configure the http server packaged in the framework to listen only to traffic incoming from the loopback.

You might wonder "Why such feature?".

In fact, if you want to use this json-rpc implementation (which is great!) as an IPC, so with the server and the client on the same host, you don't need to listen to the network incoming requests. For some cases, letting the http server listen to the network incoming requests might be seen as a 'security breach' if you plan to use the RPC only between processes that are on the same host.