### PR TITLE
Include CURL_INCLUDE_DIRS when compiling client

### DIFF
--- a/src/jsonrpccpp/CMakeLists.txt
+++ b/src/jsonrpccpp/CMakeLists.txt
@@ -37,6 +37,7 @@ if (HTTP_CLIENT)
 	list(APPEND client_connector_header "client/connectors/httpclient.h")
 	list(APPEND client_connector_source "client/connectors/httpclient.cpp")
 	list(APPEND client_connector_libs ${CURL_LIBRARIES})
+    include_directories(${CURL_INCLUDE_DIRS})
 endif()
 
 if (HTTP_SERVER)


### PR DESCRIPTION
This is required when you specify CURL_INCLUDE_DIR via commandline
to point curl include directory which is not localed at stardard directories