### PR TITLE
[cmake] Fix missing hiredis libs when using only REDIS_CLIENT

### DIFF
--- a/cmake/CMakeDependencies.cmake
+++ b/cmake/CMakeDependencies.cmake
@@ -53,7 +53,7 @@ if (${HTTP_SERVER})
 endif()
 
 # find hiredis
-if (${REDIS_SERVER})
+if (${REDIS_SERVER} OR ${REDIS_CLIENT})
 
     find_package(Hiredis REQUIRED)
     message(STATUS "Hiredis header: ${HIREDIS_INCLUDE_DIRS}")


### PR DESCRIPTION
The CMake find_package() rule was being invoked only when REDIS_SERVER
was set, causing linking errors when libjson-rpc-cpp was built with
REDIS_CLIENT only:

../../lib/libjsonrpccpp-client.so.1.0.0: undefined reference to `freeReplyObject'
../../lib/libjsonrpccpp-client.so.1.0.0: undefined reference to `redisFree'
../../lib/libjsonrpccpp-client.so.1.0.0: undefined reference to `redisCommand'
../../lib/libjsonrpccpp-client.so.1.0.0: undefined reference to `redisConnect'
collect2: error: ld returned 1 exit status

Fix the logic to search for redis also when REDIS_CLIENT is set, so that
the variables are filled correctly in.