### PR TITLE
Added support for JSON::Writer's omitEndingLineFeed() function

### DIFF
--- a/src/jsonrpccpp/client/client.cpp
+++ b/src/jsonrpccpp/client/client.cpp
@@ -12,9 +12,9 @@
 
 using namespace jsonrpc;
 
-Client::Client(IClientConnector &connector, clientVersion_t version)
+Client::Client(IClientConnector &connector, clientVersion_t version, bool omitEndingLineFeed)
     : connector(connector) {
-  this->protocol = new RpcProtocolClient(version);
+  this->protocol = new RpcProtocolClient(version, omitEndingLineFeed);
 }
 
 Client::~Client() { delete this->protocol; }

--- a/src/jsonrpccpp/client/client.h
+++ b/src/jsonrpccpp/client/client.h
@@ -27,7 +27,7 @@ namespace jsonrpc
     class Client
     {
         public:
-            Client(IClientConnector &connector, clientVersion_t version = JSONRPC_CLIENT_V2);
+            Client(IClientConnector &connector, clientVersion_t version = JSONRPC_CLIENT_V2, bool omitEndingLineFeed = false);
             virtual ~Client();
 
             void        CallMethod          (const std::string &name, const Json::Value &parameter, Json::Value& result) ;

--- a/src/jsonrpccpp/client/rpcprotocolclient.cpp
+++ b/src/jsonrpccpp/client/rpcprotocolclient.cpp
@@ -23,8 +23,8 @@ const std::string RpcProtocolClient::KEY_ERROR_CODE = "code";
 const std::string RpcProtocolClient::KEY_ERROR_MESSAGE = "message";
 const std::string RpcProtocolClient::KEY_ERROR_DATA = "data";
 
-RpcProtocolClient::RpcProtocolClient(clientVersion_t version)
-    : version(version) {}
+RpcProtocolClient::RpcProtocolClient(clientVersion_t version, bool omitEndingLineFeed)
+    : version(version), omitEndingLineFeed(omitEndingLineFeed) {}
 
 void RpcProtocolClient::BuildRequest(const std::string &method,
                                      const Json::Value &parameter,
@@ -32,6 +32,9 @@ void RpcProtocolClient::BuildRequest(const std::string &method,
   Json::Value request;
   Json::FastWriter writer;
   this->BuildRequest(1, method, parameter, request, isNotification);
+  if (omitEndingLineFeed) {
+    writer.omitEndingLineFeed();
+  }
   result = writer.write(request);
 }
 

--- a/src/jsonrpccpp/client/rpcprotocolclient.h
+++ b/src/jsonrpccpp/client/rpcprotocolclient.h
@@ -24,7 +24,7 @@ namespace jsonrpc {
     class RpcProtocolClient
     {
         public:
-            RpcProtocolClient(clientVersion_t version = JSONRPC_CLIENT_V2);
+            RpcProtocolClient(clientVersion_t version = JSONRPC_CLIENT_V2, bool omitEndingLineFeed = false);
 
             /**
              * @brief This method builds a valid json-rpc 2.0 request object based on passed parameters.
@@ -73,6 +73,7 @@ namespace jsonrpc {
 
         private:
             clientVersion_t version;
+            bool omitEndingLineFeed;
 
             void BuildRequest(int id, const std::string& method, const Json::Value& parameter, Json::Value& result, bool isNotification);
             bool ValidateResponse(const Json::Value &response);


### PR DESCRIPTION
The extra line feed left by JSON::Writer causes parsing errors with some other services (e.g. ElectrumX).
The method added here is a defaulted constructor parameter that should not break existing implementations.
That said, instead of having a "boolean" passed in, perhaps this would be better as a Flags-type field to make it more future proof?