### PR TITLE
Allow setting bind address for HTTP server.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- The `HttpServer` connector now has a `SetBindAddress` method, which can
+  be used to bind to a specific address rather than listen on all
+  interfaces of the machine (#259)
+
 ## [v1.1.1] - 2018-10-31
 
 ### Fixed

--- a/src/jsonrpccpp/client/connectors/tcpsocketclient.cpp
+++ b/src/jsonrpccpp/client/connectors/tcpsocketclient.cpp
@@ -9,7 +9,7 @@
 
 #include "tcpsocketclient.h"
 
-#ifdef __WIN32__
+#ifdef _WIN32
 #include "windowstcpsocketclient.h"
 #else
 #include "linuxtcpsocketclient.h"
@@ -20,7 +20,7 @@ using namespace std;
 
 TcpSocketClient::TcpSocketClient(const std::string &ipToConnect,
                                  const unsigned int &port) {
-#ifdef __WIN32__
+#ifdef _WIN32
   this->realSocket = new WindowsTcpSocketClient(ipToConnect, port);
 #else
   this->realSocket = new LinuxTcpSocketClient(ipToConnect, port);

--- a/src/jsonrpccpp/client/connectors/windowstcpsocketclient.cpp
+++ b/src/jsonrpccpp/client/connectors/windowstcpsocketclient.cpp
@@ -133,8 +133,8 @@ SOCKET WindowsTcpSocketClient::Connect() throw(JsonRpcException) {
     hints.ai_family = AF_INET;
     hints.ai_socktype = SOCK_STREAM;
     hints.ai_protocol = IPPROTO_TCP;
-    char port[6];
-    port = itoa(this->port, port, 10);
+	char port[6];
+	itoa(this->port, port, 10);
     DWORD retval =
         getaddrinfo(this->hostToConnect.c_str(), port, &hints, &result);
     if (retval != 0)

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -15,11 +15,13 @@
 #include <sys/types.h>
 #if defined(_WIN32) && !defined(__CYGWIN__)
 #include <ws2tcpip.h>
+#include <winsock2.h>
 #if defined(_MSC_FULL_VER) && !defined (_SSIZE_T_DEFINED)
 #define _SSIZE_T_DEFINED
 typedef intptr_t ssize_t;
 #endif // !_SSIZE_T_DEFINED */
 #else
+#include <netdb.h>
 #include <unistd.h>
 #include <sys/time.h>
 #include <sys/socket.h>
@@ -49,6 +51,18 @@ namespace jsonrpc
              */
             HttpServer(int port, const std::string& sslcert = "", const std::string& sslkey = "", int threads = 50);
 
+            ~HttpServer();
+
+            /**
+             * Sets the address at which the server will bind when started.
+             * By default, the server listens at all interfaces.  If this
+             * method is called with a non-empty string before starting the
+             * server, then it will only bind to the specified address.
+             * This method returns true on success and false if the given
+             * address could not be set as bind address.
+             */
+            bool SetBindAddress(const std::string& addr);
+
             virtual bool StartListening();
             virtual bool StopListening();
 
@@ -62,6 +76,7 @@ namespace jsonrpc
             int port;
             int threads;
             bool running;
+            struct addrinfo* bind_address = nullptr;
             std::string path_sslcert;
             std::string path_sslkey;
             std::string sslcert;

--- a/src/jsonrpccpp/server/connectors/windowstcpsocketserver.cpp
+++ b/src/jsonrpccpp/server/connectors/windowstcpsocketserver.cpp
@@ -181,7 +181,9 @@ DWORD WINAPI WindowsTcpSocketServer::GenerateResponse(LPVOID lp_data) {
       request.append(buffer, nbytes);
     }
   } while (request.find(DELIMITER_CHAR) == string::npos);
-  instance->OnRequest(request, reinterpret_cast<void *>(connection_fd));
+  std::string response;
+  instance->ProcessRequest(request, response);
+  instance->SendResponse(response, reinterpret_cast<void *>(connection_fd));
   CloseHandle(GetCurrentThread());
   return 0; // DO NOT USE ExitThread function here! ExitThread does not call
             // destructors for allocated objects and therefore it would lead to


### PR DESCRIPTION
This modifies the HTTP server connector so that the bind address can be specified if desired (e.g. to listen only locally).

See https://github.com/cinemast/libjson-rpc-cpp/issues/200.