### PR TITLE
Handle bad or malicious JSONs

### DIFF
--- a/src/jsonrpccpp/server/abstractprotocolhandler.cpp
+++ b/src/jsonrpccpp/server/abstractprotocolhandler.cpp
@@ -33,9 +33,15 @@ void AbstractProtocolHandler::HandleRequest(const std::string &request,
   Json::Value resp;
   Json::FastWriter w;
 
-  if (reader.parse(request, req, false)) {
-    this->HandleJsonRequest(req, resp);
-  } else {
+  try {
+    if (reader.parse(request, req, false)) {
+      this->HandleJsonRequest(req, resp);
+    } else {
+      this->WrapError(
+          Json::nullValue, Errors::ERROR_RPC_JSON_PARSE_ERROR,
+          Errors::GetErrorMessage(Errors::ERROR_RPC_JSON_PARSE_ERROR), resp);
+    }
+  } catch (const Json::Exception &e) {
     this->WrapError(Json::nullValue, Errors::ERROR_RPC_JSON_PARSE_ERROR,
                     Errors::GetErrorMessage(Errors::ERROR_RPC_JSON_PARSE_ERROR),
                     resp);

--- a/src/jsonrpccpp/server/rpcprotocolserver12.cpp
+++ b/src/jsonrpccpp/server/rpcprotocolserver12.cpp
@@ -27,13 +27,20 @@ void RpcProtocolServer12::HandleRequest(const std::string &request,
   Json::Value resp;
   Json::FastWriter w;
 
-  if (reader.parse(request, req, false)) {
-    this->GetHandler(req).HandleJsonRequest(req, resp);
-  } else {
+  try {
+    if (reader.parse(request, req, false)) {
+      this->GetHandler(req).HandleJsonRequest(req, resp);
+    } else {
+      this->GetHandler(req).WrapError(
+          Json::nullValue, Errors::ERROR_RPC_JSON_PARSE_ERROR,
+          Errors::GetErrorMessage(Errors::ERROR_RPC_JSON_PARSE_ERROR), resp);
+    }
+  } catch (const Json::Exception &e) {
     this->GetHandler(req).WrapError(
         Json::nullValue, Errors::ERROR_RPC_JSON_PARSE_ERROR,
         Errors::GetErrorMessage(Errors::ERROR_RPC_JSON_PARSE_ERROR), resp);
   }
+
   if (resp != Json::nullValue)
     retValue = w.write(resp);
 }


### PR DESCRIPTION
The function `Json::Reader::parse` throws exception when it is faced with bad or malicious jsons. This causes the server to crash . This PR addresses the issue and throws an RPC error instead. I would be happy to share such JSONs privately. 