### PR TITLE
Feature/json numeric type

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -75,3 +75,6 @@ Michał Górny <mgorny@gentoo.org>
 
 Trevor Vannoy <trevor.vannoy@flukecal.com>
 + fixed tcp socket client compile issues
+
+Ranganathan Balakrishnan <rangatce@gmail.com>
++ add JSON NUMERIC data type to accept both real and integer values

--- a/src/jsonrpccpp/common/procedure.cpp
+++ b/src/jsonrpccpp/common/procedure.cpp
@@ -142,6 +142,10 @@ bool Procedure::ValidateSingleParameter(jsontype_t expectedType,
     if (!value.isDouble())
       ok = false;
     break;
+  case JSON_NUMERIC:
+    if (!value.isNumeric())
+      ok = false;
+    break;
   case JSON_OBJECT:
     if (!value.isObject())
       ok = false;

--- a/src/jsonrpccpp/common/specification.h
+++ b/src/jsonrpccpp/common/specification.h
@@ -37,7 +37,8 @@ namespace jsonrpc
         JSON_INTEGER = 3,
         JSON_REAL = 4,
         JSON_OBJECT = 5,
-        JSON_ARRAY = 6
+        JSON_ARRAY = 6,
+        JSON_NUMERIC = 7
     } ;
 }
 

--- a/src/jsonrpccpp/common/specificationwriter.cpp
+++ b/src/jsonrpccpp/common/specificationwriter.cpp
@@ -54,6 +54,9 @@ Json::Value SpecificationWriter::toJsonLiteral(jsontype_t type) {
   case JSON_REAL:
     literal = 1.0;
     break;
+  case JSON_NUMERIC:
+    literal = 1.0;
+    break;
   case JSON_ARRAY:
     literal = Json::arrayValue;
     break;

--- a/src/stubgenerator/helper/cpphelper.cpp
+++ b/src/stubgenerator/helper/cpphelper.cpp
@@ -32,6 +32,9 @@ string CPPHelper::toCppType(jsontype_t type, bool isConst, bool isReference) {
   case JSON_REAL:
     result = "double";
     break;
+  case JSON_NUMERIC:
+    result = "double";
+    break;
   case JSON_STRING:
     result = "std::string";
     break;
@@ -59,6 +62,9 @@ string CPPHelper::toCppConversion(jsontype_t type) {
   case JSON_REAL:
     result = ".asDouble()";
     break;
+  case JSON_NUMERIC:
+    result = ".asDouble()";
+    break;
   case JSON_STRING:
     result = ".asString()";
     break;
@@ -79,6 +85,9 @@ string CPPHelper::toString(jsontype_t type) {
     break;
   case JSON_REAL:
     result = "jsonrpc::JSON_REAL";
+    break;
+  case JSON_NUMERIC:
+    result = "jsonrpc::JSON_NUMERIC";
     break;
   case JSON_STRING:
     result = "jsonrpc::JSON_STRING";
@@ -204,6 +213,9 @@ string CPPHelper::isCppConversion(jsontype_t type) {
     break;
   case JSON_REAL:
     result = ".isDouble()";
+    break;
+  case JSON_NUMERIC:
+    result = ".isNumeric()";
     break;
   case JSON_STRING:
     result = ".isString()";

--- a/src/test/test_common.cpp
+++ b/src/test/test_common.cpp
@@ -55,7 +55,8 @@ TEST_CASE("test_procedure_parametervalidation", TEST_MODULE) {
 
   Procedure proc2("someprocedure", PARAMS_BY_NAME, JSON_BOOLEAN, "bool",
                   JSON_BOOLEAN, "object", JSON_OBJECT, "array", JSON_ARRAY,
-                  "real", JSON_REAL, "int", JSON_INTEGER, NULL);
+                  "real", JSON_REAL, "int", JSON_INTEGER,
+                  "numeric", JSON_NUMERIC, NULL);
   Json::Value param4;
   Json::Value array;
   array.append(0);
@@ -64,6 +65,7 @@ TEST_CASE("test_procedure_parametervalidation", TEST_MODULE) {
   param4["array"] = array;
   param4["real"] = 0.332;
   param4["int"] = 3;
+  param4["numeric"] = 7;
 
   CHECK(proc2.ValidateNamedParameters(param4) == true);
 
@@ -85,6 +87,13 @@ TEST_CASE("test_procedure_parametervalidation", TEST_MODULE) {
 
   param4["int"] = "String";
   CHECK(proc2.ValidateNamedParameters(param4) == false);
+  param4["int"] = 3;
+
+  param4["numeric"] = "String";
+  CHECK(proc2.ValidateNamedParameters(param4) == false);
+
+  param4["numeric"] = 8.657;
+  CHECK(proc2.ValidateNamedParameters(param4) == true);
 }
 
 TEST_CASE("test_exception", TEST_MODULE) {


### PR DESCRIPTION
Added JSON_NUMERIC data type that can accept both integer and real (double) arguments.