### PR TITLE
Add Json::Value arg example

### DIFF
--- a/src/examples/spec.json
+++ b/src/examples/spec.json
@@ -26,6 +26,13 @@
         "returns": 7.5
     },
     {
+        "name": "calculate",
+        "params": {
+            "args": {}        
+        },
+        "returns": []
+    },
+    {
         "name": "isEqual",
         "params": [
             "string1",

--- a/src/examples/stubclient.cpp
+++ b/src/examples/stubclient.cpp
@@ -26,6 +26,17 @@ int main() {
 
     cout << " 3 + 5 = " << c.addNumbers(3, 5) << endl;
     cout << " 3.2 + 5.3 = " << c.addNumbers2(3.2, 5.3) << endl;
+    Json::Value args;
+    args["arg1"] = 1;
+    args["arg2"] = 2;
+    args["operator"] = "+";
+    Json::Value result = c.calculate(args);
+    cout << " 1 + 2 = " << result[0].asInt() << endl;
+    args["arg1"] = 3;
+    args["arg2"] = 4;
+    args["operator"] = "*";
+    result = c.calculate(args);
+    cout << " 3 * 4 = " << result[0].asInt() << endl;
     cout << "Compare: " << c.isEqual("Peter", "peter") << endl;
     cout << "Build object: " << c.buildObject("Peter", 1990) << endl;
 

--- a/src/examples/stubserver.cpp
+++ b/src/examples/stubserver.cpp
@@ -23,6 +23,7 @@ public:
   virtual std::string sayHello(const std::string &name);
   virtual int addNumbers(int param1, int param2);
   virtual double addNumbers2(double param1, double param2);
+  virtual Json::Value calculate(const Json::Value& args);
   virtual bool isEqual(const std::string &str1, const std::string &str2);
   virtual Json::Value buildObject(const std::string &name, int age);
   virtual std::string methodWithoutParameters();
@@ -35,12 +36,13 @@ MyStubServer::MyStubServer(AbstractServerConnector &connector,
 void MyStubServer::notifyServer() { cout << "Server got notified" << endl; }
 
 string MyStubServer::sayHello(const string &name) {
-    if (name == "")
-        throw JsonRpcException(-32100, "Name was empty");
-    return "Hello " + name;
+  if (name == "")
+    throw JsonRpcException(-32100, "Name was empty");
+  return "Hello " + name;
 }
 
 int MyStubServer::addNumbers(int param1, int param2) { return param1 + param2; }
+
 
 double MyStubServer::addNumbers2(double param1, double param2) {
   return param1 + param2;
@@ -48,6 +50,49 @@ double MyStubServer::addNumbers2(double param1, double param2) {
 
 bool MyStubServer::isEqual(const string &str1, const string &str2) {
   return str1 == str2;
+}
+
+Json::Value MyStubServer::calculate(const Json::Value& args) {
+  Json::Value result;
+  if((args.isMember("arg1") && args["arg1"].isInt()) &&
+    (args.isMember("arg2") && args["arg2"].isInt()) &&
+    (args.isMember("operator") && args["operator"].isString()))
+  {
+    int calculated = 0;
+
+    switch(args["operator"].asString()[0])
+    {
+      case '+':
+      {
+        calculated = args["arg1"].asInt() + args["arg2"].asInt();
+        break;
+      }
+      case '-':
+      {
+        calculated = args["arg1"].asInt() - args["arg2"].asInt();
+        break;
+      }
+      case '*':
+      {
+        calculated = args["arg1"].asInt() * args["arg2"].asInt();
+        break;
+      }
+      case '/':
+      {
+        if(args["arg2"].asInt() != 0)
+        {
+          calculated = args["arg1"].asInt() / args["arg2"].asInt();
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  
+    result.append(calculated);
+  }
+
+  return result;
 }
 
 Json::Value MyStubServer::buildObject(const string &name, int age) {


### PR DESCRIPTION
Provides a reference example for the case where we need the client to
support sending arbitrary arguments (not fixed type)