### PR TITLE
Fix double free issue if client_connection is nullptr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**I am currently working on a new C++17 implementation -> [json-rpc-cxx](https://github.com/jsonrpcx/json-rpc-cxx). It is still a work in progress, but early feedback is very welcome.**
+**I am currently working on a new C++17 implementation -> [json-rpc-cxx](https://github.com/jsonrpcx/json-rpc-cxx).**
 
 Master [![Build Status](https://travis-ci.org/cinemast/libjson-rpc-cpp.png?branch=master)](https://travis-ci.org/cinemast/libjson-rpc-cpp) [![codecov](https://codecov.io/gh/cinemast/libjson-rpc-cpp/branch/master/graph/badge.svg)](https://codecov.io/gh/cinemast/libjson-rpc-cpp)
 Develop [![Build Status](https://travis-ci.org/cinemast/libjson-rpc-cpp.png?branch=develop)](https://travis-ci.org/cinemast/libjson-rpc-cpp) [![codecov](https://codecov.io/gh/cinemast/libjson-rpc-cpp/branch/develop/graph/badge.svg)](https://codecov.io/gh/cinemast/libjson-rpc-cpp) |

--- a/docker/Centos7.Dockerfile
+++ b/docker/Centos7.Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:7
+
+ENV OS=centos7
+RUN yum -y install epel-release
+RUN yum -y install jsoncpp-devel libcurl-devel hiredis-devel redis cmake3 argtable-devel gcc-c++ wget gnutls-devel git gnutls-devel libgcrypt-devel
+ENV MICROHTTPD_VERSION=0.9.37
+RUN wget https://ftp.gnu.org/gnu/libmicrohttpd/libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz && tar xvz -f libmicrohttpd-${MICROHTTPD_VERSION}.tar.gz \
+    && cd libmicrohttpd-${MICROHTTPD_VERSION} && ./configure && make -j$(nproc) && make install
+RUN ln -sf /usr/bin/cmake3 /usr/bin/cmake
+RUN mkdir /app
+COPY docker/build_test_install.sh /app
+COPY . /app
+RUN chmod a+x /app/build_test_install.sh
+RUN cd /app && ./build_test_install.sh

--- a/docker/build_test_install.sh
+++ b/docker/build_test_install.sh
@@ -3,7 +3,7 @@ set -evu
 
 PREFIX=/usr/local
 
-if [ "$OS" == "arch" ] || [ "$OS" == "fedora" ]
+if [ "$OS" == "arch" ] || [ "$OS" == "fedora" ] || [ "$OS" == "centos7" ]
 then
 	PREFIX=/usr
 fi

--- a/src/jsonrpccpp/CMakeLists.txt
+++ b/src/jsonrpccpp/CMakeLists.txt
@@ -137,7 +137,7 @@ include_directories(${MHD_INCLUDE_DIRS})
 # setup shared common library
 if (BUILD_SHARED_LIBS)
 	add_library(jsonrpccommon SHARED ${jsonrpc_source_common} ${jsonrpc_header} ${jsonrpc_helper_source_common})
-	target_link_libraries(jsonrpccommon jsoncpp_lib_static)
+	target_link_libraries(jsonrpccommon ${JSONCPP_LIBRARY})
 	set_target_properties(jsonrpccommon PROPERTIES OUTPUT_NAME jsonrpccpp-common)
 endif()
 

--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -193,7 +193,11 @@ int HttpServer::callback(void *cls, MHD_Connection *connection, const char *url,
     client_connection->server->SendResponse("Not allowed HTTP Method",
                                             client_connection);
   }
-  delete client_connection;
+  
+  if (client_connection != nullptr)
+  {
+    delete client_connection;
+  }
   *con_cls = NULL;
 
   return MHD_YES;


### PR DESCRIPTION
`client_connection` may already be a `null pointer` in some cases. Hence, if there is no check for `nullptr`, a double-free issue may occur. 