### PR TITLE
Fix include and lib directories in pc files.

### DIFF
--- a/cmake/libjsonrpccpp-client.pc.cmake
+++ b/cmake/libjsonrpccpp-client.pc.cmake
@@ -1,5 +1,5 @@
 Name: libjsonrpccpp-client
 Description: A C++ client implementation of json-rpc.
 Version: ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}
-Libs: -L${FULL_PATH_LIBDIR} -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-client ${CLIENT_LIBS}
-Cflags: -I${FULL_PATH_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-client ${CLIENT_LIBS}
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}

--- a/cmake/libjsonrpccpp-common.pc.cmake
+++ b/cmake/libjsonrpccpp-common.pc.cmake
@@ -1,5 +1,5 @@
 Name: libjsonrpccpp-common
 Description: Common libraries for libjson-rpc-cpp
 Version: ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}
-Libs: -L${FULL_PATH_LIBDIR} -ljsoncpp
-Cflags: -I${FULL_PATH_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -ljsoncpp
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}

--- a/cmake/libjsonrpccpp-server.pc.cmake
+++ b/cmake/libjsonrpccpp-server.pc.cmake
@@ -1,5 +1,5 @@
 Name: libjsonrpccpp-server
 Description: A C++ server implementation of json-rpc.
 Version: ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}
-Libs: -L${FULL_PATH_LIBDIR} -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-server ${SERVER_LIBS}
-Cflags: -I${FULL_PATH_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -ljsoncpp -ljsonrpccpp-common -ljsonrpccpp-server ${SERVER_LIBS}
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}

--- a/cmake/libjsonrpccpp-stub.pc.cmake
+++ b/cmake/libjsonrpccpp-stub.pc.cmake
@@ -1,5 +1,5 @@
 Name: libjsonrpccpp-stub
 Description: library for stub-generation of libjson-rpc-cpp servers/clients.
 Version: ${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}
-Libs: -L${FULL_PATH_LIBDIR} -ljsoncpp -ljsonrpccpp-common
-Cflags: -I${FULL_PATH_INCLUDEDIR}
+Libs: -L${CMAKE_INSTALL_FULL_LIBDIR} -ljsoncpp -ljsonrpccpp-common
+Cflags: -I${CMAKE_INSTALL_FULL_INCLUDEDIR}


### PR DESCRIPTION
Use the correct variables (see [CMake documentation](https://cmake.org/cmake/help/v3.0/module/GNUInstallDirs.html)) for the include and lib directories in the generated pkg-config files.

The other variables are undefined and lead to misformed and unusable .pc files installed.