### PR TITLE
Added data field in error handler in JS stub generator

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -78,3 +78,7 @@ Trevor Vannoy <trevor.vannoy@flukecal.com>
 
 Ranganathan Balakrishnan <rangatce@gmail.com>
 + add JSON NUMERIC data type to accept both real and integer values
+
+Evgeny Petrov <groosha@protonmail.com>
++ added data field for error handler
++ 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Build example for Centos 7 (#267)
 - `Json::Value` example code (#281)
 - IPv6 Support for `HttpServer` (#275)
+- Added data field in error handler in JS stub generator
 
 ### Fixed
 - Incorrect README sections (#280)

--- a/src/stubgenerator/client/jsclientstubgenerator.cpp
+++ b/src/stubgenerator/client/jsclientstubgenerator.cpp
@@ -39,7 +39,7 @@ using namespace std;
                         callback_success(response.id, response.result);\n\
                     } else if (response.hasOwnProperty(\"error\")) {\n\
                         if (callback_error != null)\n\
-                            callback_error(response.error.code,response.error.message);\n\
+                            callback_error(response.error.code,response.error.message,response.error.data);\n\
                     } else {\n\
                         if (callback_error != null)\n\
                             callback_error(-32001, \"Invalid Server response: \" + response);\n\


### PR DESCRIPTION
According to [JSON-RPC](https://www.jsonrpc.org/specification#error_object) specification, the data field is optional, but valid