### PR TITLE
Use microhttpd's MHD_Result return type

### DIFF
--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -151,10 +151,10 @@ void HttpServer::SetUrlHandler(const string &url,
   this->SetHandler(NULL);
 }
 
-int HttpServer::callback(void *cls, MHD_Connection *connection, const char *url,
-                         const char *method, const char *version,
-                         const char *upload_data, size_t *upload_data_size,
-                         void **con_cls) {
+MHD_Result HttpServer::callback(void *cls, MHD_Connection *connection,
+                                const char *url, const char *method,
+                                const char *version, const char *upload_data,
+                                size_t *upload_data_size, void **con_cls) {
   (void)version;
   if (*con_cls == NULL) {
     struct mhd_coninfo *client_connection = new mhd_coninfo;

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -79,7 +79,7 @@ protected:
   std::map<std::string, IClientConnectionHandler *> urlhandler;
   struct sockaddr_in loopback_addr;
 
-  static int callback(void *cls, struct MHD_Connection *connection,
+  static MHD_Result callback(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls);

--- a/src/test/testhttpserver.cpp
+++ b/src/test/testhttpserver.cpp
@@ -41,7 +41,7 @@ std::string TestHttpServer::GetHeader(const std::string &key) {
   return "";
 }
 
-int TestHttpServer::callback(void *cls, MHD_Connection *connection,
+MHD_Result TestHttpServer::callback(void *cls, MHD_Connection *connection,
                              const char *url, const char *method,
                              const char *version, const char *upload_data,
                              size_t *upload_data_size, void **con_cls) {
@@ -69,7 +69,7 @@ int TestHttpServer::callback(void *cls, MHD_Connection *connection,
   return MHD_YES;
 }
 
-int TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
+MHD_Result TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
                                     const char *key, const char *value) {
   (void)kind;
   TestHttpServer *_this = static_cast<TestHttpServer *>(cls);

--- a/src/test/testhttpserver.h
+++ b/src/test/testhttpserver.h
@@ -36,9 +36,9 @@ namespace jsonrpc {
             std::map<std::string,std::string> headers;
             std::string response;
 
-            static int callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+            static MHD_Result callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
 
-            static int header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+            static MHD_Result header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
     };
 
 } // namespace jsonrpc


### PR DESCRIPTION
Building on Arch Linux throws some errors like the following, regarding usage of `int` rather than `MHD_Result` in return types of callback functions from libmicrohttpd.

```
libjson-rpc-cpp/src/jsonrpccpp/server/connectors/httpserver.cpp: In member function 'virtual bool jsonrpc::HttpServer::StartListening()':
libjson-rpc-cpp/src/jsonrpccpp/server/connectors/httpserver.cpp:79:60: error: invalid conversion from 'int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, size_t*, void**)' {aka 'int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)'} to 'MHD_AccessHandlerCallback' {aka 'MHD_Result (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)'} [-fpermissive]
   79 |             mhd_flags, this->port, NULL, NULL, HttpServer::callback, this,
      |                                                ~~~~~~~~~~~~^~~~~~~~
      |                                                            |
      |                                                            int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, size_t*, void**) {aka int (*)(void*, MHD_Connection*, const char*, const char*, const char*, const char*, long unsigned int*, void**)}
In file included from libjson-rpc-cpp/src/jsonrpccpp/server/connectors/httpserver.h:33,
                 from libjson-rpc-cpp/src/jsonrpccpp/server/connectors/httpserver.cpp:10:
/usr/include/microhttpd.h:2428:45: note:   initializing argument 5 of 'MHD_Daemon* MHD_start_daemon(unsigned int, uint16_t, MHD_AcceptPolicyCallback, void*, MHD_AccessHandlerCallback, void*, ...)'
 2428 |                   MHD_AccessHandlerCallback dh, void *dh_cls,
      |                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~
```

That error is caused by [recent changes](https://git.gnunet.org/libmicrohttpd.git/commit/?id=6347f514aa2388e774d5bf356df8046864e5f73c) to libmicrohttpd, released in version 0.9.71. That looks like a breaking change, since `MHD_Result` was not previously defined. I am not sure what your policy on dependency versions is, but if necessary this change could include a conditional `typedef int MHD_Result` based on the value of `MHD_VERSION`.