### PR TITLE
Add ability to set time in ListenLoop

### DIFF
--- a/src/jsonrpccpp/server/abstractthreadedserver.cpp
+++ b/src/jsonrpccpp/server/abstractthreadedserver.cpp
@@ -33,6 +33,11 @@ bool AbstractThreadedServer::StopListening() {
   return true;
 }
 
+void AbstractThreadedServer::SetWaitTime(uint microseconds)
+{
+  waitTimeMicroseconds = microseconds;
+}
+
 void AbstractThreadedServer::ListenLoop() {
   while (this->running) {
     int conn = this->CheckForConnection();
@@ -45,7 +50,7 @@ void AbstractThreadedServer::ListenLoop() {
         this->HandleConnection(conn);
       }
     } else {
-      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      std::this_thread::sleep_for(std::chrono::microseconds(waitTimeMicroseconds));
     }
   }
 }

--- a/src/jsonrpccpp/server/abstractthreadedserver.h
+++ b/src/jsonrpccpp/server/abstractthreadedserver.h
@@ -14,6 +14,7 @@ public:
 
   virtual bool StartListening();
   virtual bool StopListening();
+  virtual void SetWaitTime(uint microseconds);
 
 protected:
   /**
@@ -38,6 +39,7 @@ protected:
 
 private:
   bool running;
+  uint waitTimeMicroseconds = 1000;
   std::unique_ptr<std::thread> listenerThread;
   ThreadPool threadPool;
   size_t threads;


### PR DESCRIPTION
For some purposes the 1 millisecond wait time might be too much, hence, keeping the default value same (1000 microseconds), add a setter which helps us to set wait time accordingly.

