### PR TITLE
Master branch: Fix build, make possible to compile against old and new libmicrohttpd.

### DIFF
--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -153,10 +153,11 @@ void HttpServer::SetUrlHandler(const string &url,
   this->SetHandler(NULL);
 }
 
-int HttpServer::callback(void *cls, MHD_Connection *connection, const char *url,
-                         const char *method, const char *version,
-                         const char *upload_data, size_t *upload_data_size,
-                         void **con_cls) {
+HttpServer::MicroHttpdResult HttpServer::callback(
+  void *cls, MHD_Connection *connection, const char *url,
+  const char *method, const char *version,
+  const char *upload_data, size_t *upload_data_size,
+  void **con_cls) {
   (void)version;
   if (*con_cls == NULL) {
     struct mhd_coninfo *client_connection = new mhd_coninfo;

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -66,6 +66,12 @@ public:
   void SetUrlHandler(const std::string &url, IClientConnectionHandler *handler);
 
 private:
+#if MHD_VERSION >= 0x00097002
+  typedef MHD_Result MicroHttpdResult;
+#else
+  typedef int MicroHttpdResult;
+#endif
+
   int port;
   int threads;
   bool running;
@@ -79,10 +85,12 @@ private:
   std::map<std::string, IClientConnectionHandler *> urlhandler;
   struct sockaddr_in loopback_addr;
 
-  static int callback(void *cls, struct MHD_Connection *connection,
-                      const char *url, const char *method, const char *version,
-                      const char *upload_data, size_t *upload_data_size,
-                      void **con_cls);
+  static MicroHttpdResult callback(void *cls, struct MHD_Connection *connection,
+                                   const char *url, const char *method,
+                                   const char *version,
+                                   const char *upload_data,
+                                   size_t *upload_data_size,
+                                   void **con_cls);
 
   IClientConnectionHandler *GetHandler(const std::string &url);
 };

--- a/src/test/testhttpserver.cpp
+++ b/src/test/testhttpserver.cpp
@@ -41,7 +41,8 @@ std::string TestHttpServer::GetHeader(const std::string &key) {
   return "";
 }
 
-int TestHttpServer::callback(void *cls, MHD_Connection *connection,
+TestHttpServer::MicroHttpdResult TestHttpServer::callback(
+                             void *cls, MHD_Connection *connection,
                              const char *url, const char *method,
                              const char *version, const char *upload_data,
                              size_t *upload_data_size, void **con_cls) {
@@ -69,8 +70,9 @@ int TestHttpServer::callback(void *cls, MHD_Connection *connection,
   return MHD_YES;
 }
 
-int TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
-                                    const char *key, const char *value) {
+TestHttpServer::MicroHttpdResult TestHttpServer::header_iterator(
+                                        void *cls, MHD_ValueKind kind,
+                                        const char *key, const char *value) {
   (void)kind;
   TestHttpServer *_this = static_cast<TestHttpServer *>(cls);
   _this->headers[key] = value;

--- a/src/test/testhttpserver.h
+++ b/src/test/testhttpserver.h
@@ -31,14 +31,20 @@ namespace jsonrpc {
             std::string GetHeader(const std::string &key);
 
         private:
+#if MHD_VERSION >= 0x00097002
+            typedef MHD_Result MicroHttpdResult;
+#else
+            typedef int MicroHttpdResult;
+#endif
+
             int port;
             MHD_Daemon* daemon;
             std::map<std::string,std::string> headers;
             std::string response;
 
-            static int callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+            static MicroHttpdResult callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
 
-            static int header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+            static MicroHttpdResult header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
     };
 
 } // namespace jsonrpc


### PR DESCRIPTION
The return codes of current libmicrohttpd changed from int
to MHD_Result at some point. Make it possible to be able to
compile against the old and the new version of libmicrohttpd.

Signed-off-by: Henner Zeller <h.zeller@acm.org>