### PR TITLE
Fix building for newest g++ and CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,6 @@ project(libjson-rpc-cpp)
 cmake_policy(SET CMP0007 NEW)
 cmake_policy(SET CMP0012 NEW)
 
-if (${CMAKE_MAJOR_VERSION} GREATER 2)
-    # old policy do not use MACOSX_RPATH
-    cmake_policy(SET CMP0042 OLD)
-endif()
-
 set(MAJOR_VERSION 1)
 set(MINOR_VERSION 3)
 set(PATCH_VERSION 0)

--- a/cmake/FindArgtable.cmake
+++ b/cmake/FindArgtable.cmake
@@ -7,14 +7,14 @@
 
 find_path (
     ARGTABLE_INCLUDE_DIR
-    NAMES argtable2.h
-    DOC "argtable include dir"
+    NAMES Argtable2.h
+    DOC "Argtable include dir"
 )
 
 find_library (
     ARGTABLE_LIBRARY
-    NAMES argtable2
-    DOC "argtable library"
+    NAMES Argtable2
+    DOC "Argtable library"
 )
 
 set(ARGTABLE_INCLUDE_DIRS ${ARGTABLE_INCLUDE_DIR})
@@ -26,8 +26,8 @@ set(ARGTABLE_LIBRARIES ${ARGTABLE_LIBRARY})
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     find_library(
         ARGTABLE_LIBRARY_DEBUG
-        NAMES argtable2d
-        DOC "argtable debug library"
+        NAMES Argtable2d
+        DOC "Argtable debug library"
     )
     set(ARGTABLE_LIBRARIES optimized ${ARGTABLE_LIBRARIES} debug ${ARGTABLE_LIBRARY_DEBUG})
 endif()
@@ -35,6 +35,6 @@ endif()
 # handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(argtable DEFAULT_MSG ARGTABLE_INCLUDE_DIR ARGTABLE_LIBRARY)
+find_package_handle_standard_args(Argtable DEFAULT_MSG ARGTABLE_INCLUDE_DIR ARGTABLE_LIBRARY)
 mark_as_advanced (ARGTABLE_INCLUDE_DIR ARGTABLE_LIBRARY)
 

--- a/cmake/FindCatch.cmake
+++ b/cmake/FindCatch.cmake
@@ -1,12 +1,12 @@
 find_path(
 	CATCH_INCLUDE_DIR 
-	NAMES catch.hpp
-	DOC "catch include dir"
+	NAMES Catch.hpp
+	DOC "Catch include dir"
 )
 
 set(CATCH_INCLUDE_DIRS ${CATCH_INCLUDE_DIR})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(catch DEFAULT_MSG CATCH_INCLUDE_DIR)
+find_package_handle_standard_args(Catch DEFAULT_MSG CATCH_INCLUDE_DIR)
 mark_as_advanced (CATCH_INCLUDE_DIR)
 

--- a/cmake/FindHiredis.cmake
+++ b/cmake/FindHiredis.cmake
@@ -7,20 +7,20 @@
 
 find_path(
     HIREDIS_INCLUDE_DIR
-    NAMES hiredis hiredis.h hiredis/hiredis.h
-    DOC "hiredis include dir"
+    NAMES Hiredis Hiredis.h Hiredis/Hiredis.h
+    DOC "Hiredis include dir"
 )
 
 find_library(
     HIREDIS_LIBRARY
-    NAMES hiredis libhiredis
-    DOC "hiredis library"
+    NAMES Hiredis libHiredis
+    DOC "Hiredis library"
 )
 
 set(HIREDIS_INCLUDE_DIRS ${HIREDIS_INCLUDE_DIR})
 set(HIREDIS_LIBRARIES ${HIREDIS_LIBRARY})
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(hiredis DEFAULT_MSG HIREDIS_INCLUDE_DIR HIREDIS_LIBRARY)
+find_package_handle_standard_args(Hiredis DEFAULT_MSG HIREDIS_INCLUDE_DIR HIREDIS_LIBRARY)
 mark_as_advanced(HIREDIS_INCLUDE_DIR HIREDIS_LIBRARY)
 

--- a/cmake/FindJsoncpp.cmake
+++ b/cmake/FindJsoncpp.cmake
@@ -1,32 +1,32 @@
-# Find jsoncpp
+# Find Jsoncpp
 #
-# Find the jsoncpp includes and library
+# Find the Jsoncpp includes and library
 #
 # if you nee to add a custom library search path, do it via via CMAKE_PREFIX_PATH
 #
 # This module defines
 #  JSONCPP_INCLUDE_DIR, where to find header, etc.
-#  JSONCPP_LIBRARY, the libraries needed to use jsoncpp.
-#  JSONCPP_FOUND, If false, do not try to use jsoncpp.
-#  JSONCPP_INCLUDE_PREFIX, include prefix for jsoncpp.
-#  jsoncpp_lib_static imported library.
+#  JSONCPP_LIBRARY, the libraries needed to use Jsoncpp.
+#  JSONCPP_FOUND, If false, do not try to use Jsoncpp.
+#  JSONCPP_INCLUDE_PREFIX, include prefix for Jsoncpp.
+#  Jsoncpp_lib_static imported library.
 
 # only look in default directories
 find_path(
 	JSONCPP_INCLUDE_DIR
-	NAMES json/json.h jsoncpp/json/json.h
-	DOC "jsoncpp include dir"
+	NAMES json/json.h Jsoncpp/json/json.h
+	DOC "Jsoncpp include dir"
 )
 
 find_library(
     JSONCPP_LIBRARY
-    NAMES jsoncpp
-    DOC "jsoncpp library"
+    NAMES Jsoncpp
+    DOC "Jsoncpp library"
 )
 
-add_library(jsoncpp_lib_static UNKNOWN IMPORTED)
+add_library(Jsoncpp_lib_static UNKNOWN IMPORTED)
 set_target_properties(
-	jsoncpp_lib_static
+	Jsoncpp_lib_static
 	PROPERTIES
 	IMPORTED_LOCATION "${JSONCPP_LIBRARY}"
 	INTERFACE_INCLUDE_DIRECTORIES "${JSONCPP_INCLUDE_DIR}"
@@ -38,12 +38,12 @@ set_target_properties(
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
 	find_library(
 		JSONCPP_LIBRARY_DEBUG
-		NAMES jsoncppd
-		DOC "jsoncpp debug library"
+		NAMES Jsoncppd
+		DOC "Jsoncpp debug library"
 	)
 
 	set_target_properties(
-		jsoncpp_lib_static
+		Jsoncpp_lib_static
 		PROPERTIES
 		IMPORTED_LOCATION_DEBUG "${JSONCPP_LIBRARY_DEBUG}"
 	)
@@ -55,11 +55,11 @@ endif()
 find_path(
     JSONCPP_INCLUDE_PREFIX
     NAMES json.h
-    PATH_SUFFIXES jsoncpp/json json
+    PATH_SUFFIXES Jsoncpp/json json
 )
 
-if (${JSONCPP_INCLUDE_PREFIX} MATCHES "jsoncpp")
-    set(JSONCPP_INCLUDE_PREFIX "jsoncpp/json")
+if (${JSONCPP_INCLUDE_PREFIX} MATCHES "Jsoncpp")
+    set(JSONCPP_INCLUDE_PREFIX "Jsoncpp/json")
 else()
     set(JSONCPP_INCLUDE_PREFIX "json")
 endif()
@@ -69,5 +69,5 @@ endif()
 # handle the QUIETLY and REQUIRED arguments and set JSONCPP_FOUND to TRUE
 # if all listed variables are TRUE, hide their existence from configuration view
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(jsoncpp DEFAULT_MSG JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)
+find_package_handle_standard_args(Jsoncpp DEFAULT_MSG JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)
 mark_as_advanced (JSONCPP_INCLUDE_DIR JSONCPP_LIBRARY)

--- a/cmake/FindMHD.cmake
+++ b/cmake/FindMHD.cmake
@@ -28,12 +28,12 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     find_library(
         MHD_LIBRARY_DEBUG
         NAMES microhttpd_d microhttpd-10_d libmicrohttpd_d libmicrohttpd-dll_d
-        DOC "mhd debug library"
+        DOC "MHD debug library"
     )
     set(MHD_LIBRARIES optimized ${MHD_LIBRARIES} debug ${MHD_LIBRARY_DEBUG})
 endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(mhd DEFAULT_MSG MHD_INCLUDE_DIR MHD_LIBRARY)
+find_package_handle_standard_args(MHD DEFAULT_MSG MHD_INCLUDE_DIR MHD_LIBRARY)
 mark_as_advanced(MHD_INCLUDE_DIR MHD_LIBRARY)
 

--- a/src/jsonrpccpp/server/connectors/httpserver.cpp
+++ b/src/jsonrpccpp/server/connectors/httpserver.cpp
@@ -153,7 +153,7 @@ void HttpServer::SetUrlHandler(const string &url,
   this->SetHandler(NULL);
 }
 
-int HttpServer::callback(void *cls, MHD_Connection *connection, const char *url,
+MHD_Result HttpServer::callback(void *cls, MHD_Connection *connection, const char *url,
                          const char *method, const char *version,
                          const char *upload_data, size_t *upload_data_size,
                          void **con_cls) {

--- a/src/jsonrpccpp/server/connectors/httpserver.h
+++ b/src/jsonrpccpp/server/connectors/httpserver.h
@@ -79,7 +79,7 @@ private:
   std::map<std::string, IClientConnectionHandler *> urlhandler;
   struct sockaddr_in loopback_addr;
 
-  static int callback(void *cls, struct MHD_Connection *connection,
+  static MHD_Result callback(void *cls, struct MHD_Connection *connection,
                       const char *url, const char *method, const char *version,
                       const char *upload_data, size_t *upload_data_size,
                       void **con_cls);

--- a/src/test/testhttpserver.cpp
+++ b/src/test/testhttpserver.cpp
@@ -41,7 +41,7 @@ std::string TestHttpServer::GetHeader(const std::string &key) {
   return "";
 }
 
-int TestHttpServer::callback(void *cls, MHD_Connection *connection,
+MHD_Result TestHttpServer::callback(void *cls, MHD_Connection *connection,
                              const char *url, const char *method,
                              const char *version, const char *upload_data,
                              size_t *upload_data_size, void **con_cls) {
@@ -69,7 +69,7 @@ int TestHttpServer::callback(void *cls, MHD_Connection *connection,
   return MHD_YES;
 }
 
-int TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
+MHD_Result TestHttpServer::header_iterator(void *cls, MHD_ValueKind kind,
                                     const char *key, const char *value) {
   (void)kind;
   TestHttpServer *_this = static_cast<TestHttpServer *>(cls);

--- a/src/test/testhttpserver.h
+++ b/src/test/testhttpserver.h
@@ -36,9 +36,9 @@ namespace jsonrpc {
             std::map<std::string,std::string> headers;
             std::string response;
 
-            static int callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
+            static MHD_Result callback(void *cls, struct MHD_Connection *connection, const char *url, const char *method, const char *version, const char *upload_data, size_t *upload_data_size, void **con_cls);
 
-            static int header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
+            static MHD_Result header_iterator (void *cls, enum MHD_ValueKind kind, const char *key, const char *value);
     };
 
 } // namespace jsonrpc


### PR DESCRIPTION
Some warnings appeared during the _CMake_ build process, where the names of the packages were not correctly specified in its type casing and some policy was not needed. Those changes are reflected in the `*.cmake` modified files.

Added to that, some slight modifications on the return type for `callback` and `header_iterator` functions were required for accomplishing the compilation process; these changes were done as well.

Tests have passed successfully after running the `build/bin/unit_testsuite` file with a running _Redis_ server in the localhost.