### PR TITLE
Build instruction update in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Build
 -----
 
 ```sh
-git clone git://github.com/cinemast/libjson-rpc-cpp.git
+git clone https://github.com/cinemast/libjson-rpc-cpp.git
 mkdir -p libjson-rpc-cpp/build
 cd libjson-rpc-cpp/build
 cmake .. && make


### PR DESCRIPTION
Updated link to clone from GitHub. Was getting error due to outdated link

```
Cloning into 'libjson-rpc-cpp'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

New link should mitigate the issue for anyone using the ReadMe.